### PR TITLE
Release shaded jar - Let shade plugin overwrite versioned artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ target/
 .imageupdate/
 dockerfile-image-update-itest/src/test/
 test-results/
+dependency-reduced-pom.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ LABEL version="0.1"
 
 MAINTAINER dvastrata@salesforce.com
 
-ADD dockerfile-image-update/target/dockerfile-image-update.jar /
+ADD dockerfile-image-update/target/dockerfile-image-update-1.0-SNAPSHOT.jar /dockerfile-image-update.jar
 
 ENTRYPOINT ["java", "-jar", "/dockerfile-image-update.jar"]

--- a/README.md
+++ b/README.md
@@ -63,61 +63,73 @@ export git_api_url=https://api.github.com
 export git_api_token=my_github_token
 docker run --rm -e git_api_token -e git_api_url salesforce/dockerfile-image-update <COMMAND> <PARAMETERS>
 ```
-    usage: dockerfile-image-update [-h] [-o ORG] [-b BRANCH] [-g GHAPI] [-f] [-m M] [-c C] COMMAND ...
-    
-    Image Updates through Pull Request Automator
-    
-    optional arguments:
-      -h, --help                   show this help message and exit
-      -o ORG, --org ORG            search within specific organization (default: all of github)
-      -b BRANCH, --branch BRANCH   make pull requests for given branch name (default: master)
-      -g GHAPI, --ghapi GHAPI      link to github api; overrides environment variable
-      -f, --auto-merge             NOT IMPLEMENTED / set to automatically merge pull requests if available
-      -m PULL_REQ_MESSAGE          message to provide for pull requests
-      -c COMMIT_MESSAGE            additional commit message for the commits in pull requests
-    
-    subcommands:
-      Specify which feature to perform
-    
-      COMMAND                FEATURE
-        all                  updates all repositories' Dockerfiles
-        child                updates one specific repository with given tag
-        parent               updates all repositories' Dockerfiles with given base image
 
-* The `all` command: specify an image-to-tag store (a repository name on GitHub that contains a file called store.json); looks through the JSON file and checks/updates all the base images in GitHub to the tag in the store.
+```bash
+usage: dockerfile-image-update [-h] [-o ORG] [-b BRANCH] [-g GHAPI] [-f] [-m M] [-c C] COMMAND ...
 
-    usage: dockerfile-image-update all [-h] <IMG_TAG_STORE>
-    
-    positional arguments:
-      <IMG_TAG_STORE>        REQUIRED
-    
-    optional arguments:
-      -h, --help             show this help message and exit
+Image Updates through Pull Request Automator
 
-* The `child` command: forcefully updates a repository's Dockerfile(s) to given tag. If specified a store, it will also forcefully update the store.
+optional arguments:
+  -h, --help                   show this help message and exit
+  -o ORG, --org ORG            search within specific organization (default: all of github)
+  -b BRANCH, --branch BRANCH   make pull requests for given branch name (default: master)
+  -g GHAPI, --ghapi GHAPI      link to github api; overrides environment variable
+  -f, --auto-merge             NOT IMPLEMENTED / set to automatically merge pull requests if available
+  -m PULL_REQ_MESSAGE          message to provide for pull requests
+  -c COMMIT_MESSAGE            additional commit message for the commits in pull requests
 
-    usage: dockerfile-image-update child [-h] [-s <IMG_TAG_STORE>] <GIT_REPO> <IMG> <FORCE_TAG>
-    
-    positional arguments:
-      <GIT_REPO>             REQUIRED
-      <IMG>                  REQUIRED
-      <FORCE_TAG>            REQUIRED
-    
-    optional arguments:
-      -h, --help             show this help message and exit
-      -s <IMG_TAG_STORE>     OPTIONAL
+subcommands:
+  Specify which feature to perform
 
-* The `parent` command: given an image, tag, and store, it will create pull requests for any Dockerfiles that has the image as a base image and an outdated tag. It also updates the store. 
+  COMMAND                FEATURE
+    all                  updates all repositories' Dockerfiles
+    child                updates one specific repository with given tag
+    parent               updates all repositories' Dockerfiles with given base image
+```
 
-    usage: dockerfile-image-update parent [-h] <IMG> <TAG> <IMG_TAG_STORE>
-    
-    positional arguments:
-      <IMG>                  REQUIRED
-      <TAG>                  REQUIRED
-      <IMG_TAG_STORE>        REQUIRED
-    
-    optional arguments:
-      -h, --help             show this help message and exit
+#### The `all` command
+Specify an image-to-tag store (a repository name on GitHub that contains a file called store.json); looks through the JSON file and checks/updates all the base images in GitHub to the tag in the store.
+
+```bash
+usage: dockerfile-image-update all [-h] <IMG_TAG_STORE>
+
+positional arguments:
+  <IMG_TAG_STORE>        REQUIRED
+
+optional arguments:
+  -h, --help             show this help message and exit
+```
+
+#### The `child` command
+Forcefully updates a repository's Dockerfile(s) to given tag. If specified a store, it will also forcefully update the store.
+
+```bash
+usage: dockerfile-image-update child [-h] [-s <IMG_TAG_STORE>] <GIT_REPO> <IMG> <FORCE_TAG>
+
+positional arguments:
+  <GIT_REPO>             REQUIRED
+  <IMG>                  REQUIRED
+  <FORCE_TAG>            REQUIRED
+
+optional arguments:
+  -h, --help             show this help message and exit
+  -s <IMG_TAG_STORE>     OPTIONAL
+```
+
+#### The `parent` command
+Given an image, tag, and store, it will create pull requests for any Dockerfiles that has the image as a base image and an outdated tag. It also updates the store. 
+
+```bash
+usage: dockerfile-image-update parent [-h] <IMG> <TAG> <IMG_TAG_STORE>
+
+positional arguments:
+  <IMG>                  REQUIRED
+  <TAG>                  REQUIRED
+  <IMG_TAG_STORE>        REQUIRED
+
+optional arguments:
+  -h, --help             show this help message and exit
+```
 
 Developer Guide
 ===============

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/salesforce/dockerfile-image-update.svg?branch=master)](https://travis-ci.org/salesforce/dockerfile-image-update)
 [![Coverage Status](https://coveralls.io/repos/github/salesforce/dockerfile-image-update/badge.svg?branch=master)](https://coveralls.io/github/salesforce/dockerfile-image-update?branch=master)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.salesforce.dockerfile-image-update/dockerfile-image-update/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.salesforce.dockerfile-image-update/dockerfile-image-update)
 
 # Dockerfile Image Updater
 
@@ -62,7 +63,6 @@ export git_api_url=https://api.github.com
 export git_api_token=my_github_token
 docker run --rm -e git_api_token -e git_api_url salesforce/dockerfile-image-update <COMMAND> <PARAMETERS>
 ```
-    ```
     usage: dockerfile-image-update [-h] [-o ORG] [-b BRANCH] [-g GHAPI] [-f] [-m M] [-c C] COMMAND ...
     
     Image Updates through Pull Request Automator
@@ -83,9 +83,9 @@ docker run --rm -e git_api_token -e git_api_url salesforce/dockerfile-image-upda
         all                  updates all repositories' Dockerfiles
         child                updates one specific repository with given tag
         parent               updates all repositories' Dockerfiles with given base image
-    ```
+
 * The `all` command: specify an image-to-tag store (a repository name on GitHub that contains a file called store.json); looks through the JSON file and checks/updates all the base images in GitHub to the tag in the store.
-    ```
+
     usage: dockerfile-image-update all [-h] <IMG_TAG_STORE>
     
     positional arguments:
@@ -93,9 +93,9 @@ docker run --rm -e git_api_token -e git_api_url salesforce/dockerfile-image-upda
     
     optional arguments:
       -h, --help             show this help message and exit
-    ```
+
 * The `child` command: forcefully updates a repository's Dockerfile(s) to given tag. If specified a store, it will also forcefully update the store.
-    ```
+
     usage: dockerfile-image-update child [-h] [-s <IMG_TAG_STORE>] <GIT_REPO> <IMG> <FORCE_TAG>
     
     positional arguments:
@@ -106,9 +106,9 @@ docker run --rm -e git_api_token -e git_api_url salesforce/dockerfile-image-upda
     optional arguments:
       -h, --help             show this help message and exit
       -s <IMG_TAG_STORE>     OPTIONAL
-    ```
+
 * The `parent` command: given an image, tag, and store, it will create pull requests for any Dockerfiles that has the image as a base image and an outdated tag. It also updates the store. 
-    ```
+
     usage: dockerfile-image-update parent [-h] <IMG> <TAG> <IMG_TAG_STORE>
     
     positional arguments:
@@ -118,7 +118,6 @@ docker run --rm -e git_api_token -e git_api_url salesforce/dockerfile-image-upda
     
     optional arguments:
       -h, --help             show this help message and exit
-    ```
 
 Developer Guide
 ===============
@@ -132,7 +131,7 @@ mvn clean install
 ### Running locally
 ```
 cd dockerfile-image-update/target
-java -jar dockerfile-image-update.jar <COMMAND> <PARAMETERS>
+java -jar dockerfile-image-update-1.0-SNAPSHOT.jar <COMMAND> <PARAMETERS>
 ```
 
 ### Creating a new feature

--- a/README.md
+++ b/README.md
@@ -28,21 +28,21 @@ User Guide
 The tool has three modes
  1. `all` - Reads store that declares the docker images and versions that you intend others to use. 
  Example:
-```
+```commandline
 export git_api_url=https://api.github.com
 export git_api_token=my_github_token
 docker run --rm -e git_api_token -e git_api_url salesforce/dockerfile-image-update all image-to-tag-store
 ```
  2. `parent` - Searches github for images that use a specified image name and sends pull requests if the image tag doesn't match intended tag. The intended image with tag is passed in the command line parameters. The intended image-to-tag mapping is persisted in a store in a specified git repository under the token owner. 
 Example:
-```
+```commandline
 export git_api_url=https://api.github.com
 export git_api_token=my_github_token
 docker run --rm -e git_api_token -e git_api_url salesforce/dockerfile-image-update parent my_org/my_image v1.0.1 image-to-tag-store
 ```
  3. `child` - Given a specific git repo, sends a pull request to update the image to a given version. You can optionally persist the image version combination in the image-to-tag store. 
 Example:
-```
+```commandline
 export git_api_url=https://api.github.com
 export git_api_token=my_github_token
 docker run --rm -e git_api_token -e git_api_url salesforce/dockerfile-image-update child my_gh_org/my_gh_repo my_image_name v1.0.1
@@ -58,13 +58,13 @@ This tool may create a LOT of forks in your account. All pull requests created a
 
 ### How to use it
 Our recommendation is to run it as a docker container:
-```
+```commandline
 export git_api_url=https://api.github.com
 export git_api_token=my_github_token
 docker run --rm -e git_api_token -e git_api_url salesforce/dockerfile-image-update <COMMAND> <PARAMETERS>
 ```
 
-```bash
+```commandline
 usage: dockerfile-image-update [-h] [-o ORG] [-b BRANCH] [-g GHAPI] [-f] [-m M] [-c C] COMMAND ...
 
 Image Updates through Pull Request Automator
@@ -90,7 +90,7 @@ subcommands:
 #### The `all` command
 Specify an image-to-tag store (a repository name on GitHub that contains a file called store.json); looks through the JSON file and checks/updates all the base images in GitHub to the tag in the store.
 
-```bash
+```commandline
 usage: dockerfile-image-update all [-h] <IMG_TAG_STORE>
 
 positional arguments:
@@ -103,7 +103,7 @@ optional arguments:
 #### The `child` command
 Forcefully updates a repository's Dockerfile(s) to given tag. If specified a store, it will also forcefully update the store.
 
-```bash
+```commandline
 usage: dockerfile-image-update child [-h] [-s <IMG_TAG_STORE>] <GIT_REPO> <IMG> <FORCE_TAG>
 
 positional arguments:
@@ -119,7 +119,7 @@ optional arguments:
 #### The `parent` command
 Given an image, tag, and store, it will create pull requests for any Dockerfiles that has the image as a base image and an outdated tag. It also updates the store. 
 
-```bash
+```commandline
 usage: dockerfile-image-update parent [-h] <IMG> <TAG> <IMG_TAG_STORE>
 
 positional arguments:
@@ -134,14 +134,14 @@ optional arguments:
 Developer Guide
 ===============
 ### Building
-```
+```commandline
 git clone https://github.com/salesforce/dockerfile-image-update.git
 cd dockerfile-image-update
 mvn clean install
 ```
 
 ### Running locally
-```
+```commandline
 cd dockerfile-image-update/target
 java -jar dockerfile-image-update-1.0-SNAPSHOT.jar <COMMAND> <PARAMETERS>
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
             # This allows us to get our test results back to workspace for the pipeline to pick up
             - ./test-results:/tmp/test-results
             # Place integration test into the component so that we don't have to ship integration tests inside the component
-            - ./dockerfile-image-update-itest/target/integration-test.jar:/tmp/integration-test.jar
+            - ./dockerfile-image-update-itest/target/integration-test-1.0-SNAPSHOT.jar:/tmp/integration-test.jar
             # If you have a secret file, you can volume mount the file to gain access to it
             # export user_itest_secrets_file_secret=/path/to/secretFile in shell
             # For CI purposes, the secret file can be added to Jenkins Credential Store with the id user_itest_secrets_file

--- a/dockerfile-image-update-itest/pom.xml
+++ b/dockerfile-image-update-itest/pom.xml
@@ -77,7 +77,6 @@
                                     <mainClass>com.salesforce.dockerfileimageupdate.itest.TestStarter</mainClass>
                                 </transformer>
                             </transformers>
-                            <finalName>integration-test</finalName>
                         </configuration>
                     </execution>
                 </executions>

--- a/dockerfile-image-update/pom.xml
+++ b/dockerfile-image-update/pom.xml
@@ -79,7 +79,6 @@
                                     <mainClass>com.salesforce.dockerfileimageupdate.CommandLine</mainClass>
                                 </transformer>
                             </transformers>
-                            <finalName>dockerfile-image-update</finalName>
                         </configuration>
                     </execution>
                 </executions>

--- a/dockerfile-image-update/pom.xml
+++ b/dockerfile-image-update/pom.xml
@@ -49,7 +49,16 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>github-api</artifactId>
+            <version>1.92</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.kohsuke</groupId>
-            <artifactId>github-api</artifactId>
-            <version>1.92</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>
@@ -74,11 +69,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.8.2</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
This is default behavior and we likely wouldn't use the unshaded jar for
anything. Also need to add dependency-reduced-pom.xml to .gitignore