### PR TITLE
Fixing child sub command to handle submodules in a git repo

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -114,6 +114,10 @@ public class DockerfileGitHubUtil {
 
     protected void modifyOnGithubRecursive(GHRepository repo, GHContent content,
                                            String branch, String img, String tag) throws IOException {
+        /* Download url is used here to identify submodules as in listing content of repo API of git provides
+         * type for submodule as file, and hence leads to NPE as download url of submodule is null.
+         * Also in child sub command, we should not iterate over the contents of submodule as it is a different repo.
+         */
         if (content.isFile() && content.getDownloadUrl() != null) {
             modifyOnGithub(content, branch, img, tag, "");
         } else if(content.isDirectory()) {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -114,9 +114,9 @@ public class DockerfileGitHubUtil {
 
     protected void modifyOnGithubRecursive(GHRepository repo, GHContent content,
                                            String branch, String img, String tag) throws IOException {
-        if (content.isFile()) {
+        if (content.isFile() && content.getDownloadUrl() != null) {
             modifyOnGithub(content, branch, img, tag, "");
-        } else {
+        } else if(content.isDirectory()) {
             for (GHContent newContent : repo.getDirectoryContent(content.getPath(), branch)) {
                 modifyOnGithubRecursive(repo, newContent, branch, img, tag);
             }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -114,7 +114,7 @@ public class DockerfileGitHubUtil {
 
     protected void modifyOnGithubRecursive(GHRepository repo, GHContent content,
                                            String branch, String img, String tag) throws IOException {
-        /* Download url is used here to identify submodules as in listing content of repo API of git provides
+        /* Download url is used here to identify submodules as in listing directory content API of git provides
          * type for submodule as file, and hence leads to NPE as download url of submodule is null.
          * Also in child sub command, we should not iterate over the contents of submodule as it is a different repo.
          */

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -234,6 +234,7 @@ public class DockerfileGitHubUtilTest {
         Iterator<GHContent> treeIterator = mock(Iterator.class);
         GHContent content = mock(GHContent.class);
         when(content.isFile()).thenReturn(false, true);
+        when(content.getDownloadUrl()).thenReturn(null,  " ");
         when(content.isDirectory()).thenReturn(true, false);
         when(content.getPath()).thenReturn("path");
         when(content.read()).thenReturn(new InputStream() {
@@ -255,7 +256,8 @@ public class DockerfileGitHubUtilTest {
         dockerfileGitHubUtil.modifyOnGithubRecursive(repo, content, branch, img, tag);
 
         verify(content, times(6)).isFile();
-
+        verify(content, times(2)).isDirectory();
+        verify(content, times(5)).getDownloadUrl();
     }
 
     @Test

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -234,6 +234,7 @@ public class DockerfileGitHubUtilTest {
         Iterator<GHContent> treeIterator = mock(Iterator.class);
         GHContent content = mock(GHContent.class);
         when(content.isFile()).thenReturn(false, true);
+        when(content.isDirectory()).thenReturn(true, false);
         when(content.getPath()).thenReturn("path");
         when(content.read()).thenReturn(new InputStream() {
             @Override


### PR DESCRIPTION
In case of child subcommand, When dockerfile-image-update jar iterates through each element in the repo, it considers submodules as file and tries to download it to view, but sub modules has "download_url": null and hence NPE comes as following
Exception in thread "main" java.lang.NullPointerException
at org.kohsuke.github.GitHub.getApiURL(GitHub.java:297)
at org.kohsuke.github.Requester.asStream(Requester.java:327)
at org.kohsuke.github.GHContent.read(GHContent.java:117)
at com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil.modifyOnGithub(DockerfileGitHubUtil.java:133)


I further investigated and found that the problem is not entirely on dockerfile-image-update side. Git APIs restrains the tool due to backward compatibility:

Git itself states that "When listing the contents of a directory, submodules have their "type" specified as "file". Logically, the value should be "submodule". This behavior exists in API v3 for backwards compatibility purposes. In the next major version of the API, the type will be returned as "submodule"."
Refer Link: https://developer.github.com/v3/repos/contents/

When I access list of contents using URL https://github.com/api/v3/repos/org/repo/contents?ref=master then a submodule('subm') has type as file

but when I access using https://github.com/api/v3/repos/org/repo/contents/subm?ref=master then type is submodule.

Hence, when we iterate the contents fetched via list Contents API in DockerfileGitHubUtil.modifyAllOnGithub then we see a submodule as a file and hence we try to get its content, instead of skipping it, resulting in failure.

Ideally git contents API should say the type as submodule, but as we cant change that , hence I see 3 possible fixes here :
- When we try to fetch the content of individual file then we hit content api for that single element and check whether its a submodule or not.
- We see that git url of the individual element in contents list is pointing to some other repo, which is the case for submodule
- We rely on download url. If download url of a element is null and its type is not a directory then it has to be submodule.
 
I think 3rd fix seems plausible and hence modifed DockerfileGitHubUtil.modifyOnGithubRecursive method.

 