### PR TITLE
 Fix #39 where untagged images => bad Dockerfile

### DIFF
--- a/dockerfile-image-update/pom.xml
+++ b/dockerfile-image-update/pom.xml
@@ -55,6 +55,11 @@
             <version>2.8.2</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.7</version>
+        </dependency>
+        <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
             <version>1.93</version>

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/FromInstruction.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/FromInstruction.java
@@ -77,6 +77,13 @@ public class FromInstruction {
         }
     }
 
+    /**
+     * Internal API to get a new FromInstruction from an existing object
+     * @param baseImageName baseImageName to add
+     * @param tag tag to add
+     * @param additionalParts additionalParts to add
+     * @param comments comments to add
+     */
     private FromInstruction(String baseImageName, String tag, List<String> additionalParts, String comments) {
         this.baseImageName = baseImageName;
         this.tag = tag;
@@ -84,6 +91,11 @@ public class FromInstruction {
         this.comments = comments;
     }
 
+    /**
+     * Get a new {@code FromInstruction} the same as this but with the {@code tag} set as {@code newTag}
+     * @param newTag
+     * @return
+     */
     public FromInstruction getFromInstructionWithNewTag(String newTag) {
         return new FromInstruction(baseImageName, newTag, additionalParts, comments);
     }
@@ -100,6 +112,9 @@ public class FromInstruction {
         return false;
     }
 
+    /**
+     * @return a String representation of a FROM instruction line in Dockerfile. No new line at the end
+     */
     @Override
     public String toString() {
         StringBuilder stringBuilder = new StringBuilder(NAME);
@@ -125,6 +140,12 @@ public class FromInstruction {
         return baseImageName;
     }
 
+    /**
+     * Check to see if the {@code baseImageName} in this object is the {@code imageToFind} without
+     * the other details (e.g. registry)
+     * @param imageToFind the image name to search for
+     * @return is {@code baseImageName} the same as {@code imageToFind} without extra things like registry
+     */
     public boolean hasBaseImage(String imageToFind) {
         return baseImageName != null &&
                 imageToFind != null &&

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/FromInstruction.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/FromInstruction.java
@@ -1,0 +1,171 @@
+package com.salesforce.dockerfileimageupdate.model;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This class represents a FROM instruction line in a Dockerfile and contains methods to determine whether a line
+ * is a FROM instruction. For more information: https://docs.docker.com/engine/reference/builder/#from
+ */
+public class FromInstruction {
+
+    private static final String NAME = "FROM";
+    private static final String INVALID_INSTRUCTION_LINE = "You have not provided a valid FROM instruction line.";
+    /**
+     * The name of the base image
+     */
+    private final String baseImageName;
+    /**
+     * The tag of the base image
+     */
+    private final String tag;
+    /**
+     * As of writing, this could include {@code AS name} to run a multi-stage build
+     */
+    private final List<String> additionalParts;
+    /**
+     * Comment starting with #
+     */
+    private final String comments;
+
+    /**
+     * Accepts a FROM instruction line from a Dockerfile
+     * See {@code isFromInstruction} to ensure you're passing a valid line in.
+     *
+     * @param fromInstructionLine a FROM instruction line from a Dockerfile
+     */
+    public FromInstruction(String fromInstructionLine) {
+        if (!isFromInstruction(fromInstructionLine)) {
+            throw new IllegalArgumentException(INVALID_INSTRUCTION_LINE);
+        }
+        String lineWithoutComment = fromInstructionLine;
+        int commentIndex = fromInstructionLine.indexOf("#");
+        if (commentIndex >= 0) {
+            comments = fromInstructionLine.substring(commentIndex);
+            lineWithoutComment = fromInstructionLine.substring(0, commentIndex);
+        } else {
+            comments = null;
+        }
+        // Trim the space now that we don't have comments to worry about
+        lineWithoutComment = lineWithoutComment.trim();
+        String[] lineParts = lineWithoutComment.split("\\s+");
+
+        if (lineParts.length > 1) {
+            // The image will be after the FROM part
+            String dockerFileImage = lineParts[1];
+            String[] imageAndTag = dockerFileImage.split(":");
+            baseImageName = imageAndTag[0];
+
+            if (imageAndTag.length > 1) {
+                tag = imageAndTag[1];
+            } else {
+                tag = null;
+            }
+
+            if (lineParts.length > 2) {
+                additionalParts = ImmutableList.copyOf(Arrays.asList(lineParts).subList(2, lineParts.length));
+            } else {
+                additionalParts = ImmutableList.of();
+            }
+        } else {
+            baseImageName = null;
+            tag = null;
+            additionalParts = ImmutableList.of();
+        }
+    }
+
+    private FromInstruction(String baseImageName, String tag, List<String> additionalParts, String comments) {
+        this.baseImageName = baseImageName;
+        this.tag = tag;
+        this.additionalParts = ImmutableList.copyOf(additionalParts);
+        this.comments = comments;
+    }
+
+    public FromInstruction getFromInstructionWithNewTag(String newTag) {
+        return new FromInstruction(baseImageName, newTag, additionalParts, comments);
+    }
+
+    /**
+     * Determines whether the line is a FROM instruction line in a Dockerfile
+     * @param dockerFileLine a single line from a Dockerfile
+     * @return the line is a FROM instruction line or not
+     */
+    public static boolean isFromInstruction(String dockerFileLine) {
+        if (StringUtils.isNotBlank(dockerFileLine)) {
+            return dockerFileLine.trim().startsWith(FromInstruction.NAME);
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder stringBuilder = new StringBuilder(NAME);
+        stringBuilder.append(" ");
+        stringBuilder.append(baseImageName);
+        if (hasTag()) {
+            stringBuilder.append(String.format(":%s", tag.trim()));
+        }
+        for (String part : additionalParts) {
+            if (StringUtils.isNotBlank(part)) {
+                stringBuilder.append(String.format(" %s", part.trim()));
+            }
+        }
+
+        if (hasComments()) {
+            stringBuilder.append(String.format(" %s", comments));
+        }
+
+        return stringBuilder.toString();
+    }
+
+    public String getBaseImageName() {
+        return baseImageName;
+    }
+
+    public boolean hasBaseImage(String imageToFind) {
+        return baseImageName != null &&
+                imageToFind != null &&
+                baseImageName.endsWith(imageToFind);
+    }
+
+    /**
+     * @return whether the {@code FromInstruction} has a {@code tag}
+     */
+    public boolean hasTag() {
+        return tag != null;
+    }
+
+    /**
+     * Determines whether the {@code tag} and {@code expectedTag} are the same
+     * @param expectedTag the tag to compare against FromInstruction's {@code tag}
+     * @return {@code true} if the 2 tags are different
+     */
+    public boolean hasADifferentTag(String expectedTag) {
+        if (tag == null && expectedTag == null) {
+            return false;
+        }
+        if (tag == null || expectedTag == null) {
+            return true;
+        }
+        return !tag.trim().equals(expectedTag.trim());
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public List<String> getAdditionalParts() {
+        return additionalParts;
+    }
+
+    public boolean hasComments() {
+        return comments != null;
+    }
+
+    public String getComments() {
+        return comments;
+    }
+}

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
@@ -28,7 +28,7 @@ public class Constants {
     public static final String GIT_API = "ghapi";
     public static final String GIT_ORG = "org";
     public static final String GIT_BRANCH = "branch";
-    public static final String BASE_IMAGE_INST = "FROM";
+    public static final String FROM_INSTRUCTION = "FROM";
     public static final String PULL_REQ_ID = "f9ed6ea5-6e74-4338-a629-50c5c6807a6b";
     public static final String STORE_JSON_FILE = "store.json";
     public static final String GIT_AUTO_MERGE = "f";

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
@@ -10,14 +10,13 @@ package com.salesforce.dockerfileimageupdate.utils;
 
 
 /**
- *
  * @author minho-park
- *
  */
 public class Constants {
 
     /* Should never be instantiated. */
-    private Constants () { }
+    private Constants() {
+    }
 
     public static final String COMMAND = "command";
     public static final String GIT_REPO = "<GIT_REPO>";
@@ -28,7 +27,6 @@ public class Constants {
     public static final String GIT_API = "ghapi";
     public static final String GIT_ORG = "org";
     public static final String GIT_BRANCH = "branch";
-    public static final String FROM_INSTRUCTION = "FROM";
     public static final String PULL_REQ_ID = "f9ed6ea5-6e74-4338-a629-50c5c6807a6b";
     public static final String STORE_JSON_FILE = "store.json";
     public static final String GIT_AUTO_MERGE = "f";

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -208,30 +208,6 @@ public class DockerfileGitHubUtil {
         return modified;
     }
 
-    /**
-     * This method gets the parts of a line split by whitespace. Comments will be the last part and will maintain
-     * whitespace after the #
-     * e.g.
-     * "FROM dockerimage:3 # some comment" == ["FROM", "dockerimage:3", "# some comment"]
-     * @param lineToSplit the line to split
-     * @return split array of Strings
-     */
-    protected static List<String> getLineParts(String lineToSplit) {
-        String lineWithoutComment = lineToSplit;
-        int commentIndex = lineToSplit.indexOf("#");
-        String commentString = "";
-        if (commentIndex >= 0) {
-            commentString = lineToSplit.substring(commentIndex);
-            lineWithoutComment = lineToSplit.substring(0, commentIndex);
-        }
-        String[] splitForWhitespace = lineWithoutComment.trim().split("\\s+");
-        List<String> lineParts = new ArrayList<>(Arrays.asList(splitForWhitespace));
-        if (StringUtils.isNotEmpty(commentString)) {
-            lineParts.add(commentString);
-        }
-        return lineParts;
-    }
-
     /* The store link should be a repository name on Github. */
     public void updateStore(String store, String img, String tag) throws IOException {
         if (store == null) {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -173,28 +173,6 @@ public class DockerfileGitHubUtil {
         return modified;
     }
 
-    protected int getEndOfTagLength(String tag) {
-        // TODO: There are probably more cases, but are unlikely
-        int smallestIdx = Integer.MAX_VALUE;
-        int spaceIdx = tag.indexOf(' ');
-        if (spaceIdx > -1) {
-            smallestIdx = spaceIdx;
-        }
-        int tabIdx = tag.indexOf('\t');
-        if (tabIdx > -1) {
-            smallestIdx = Math.min(tabIdx, smallestIdx);
-        }
-        int commentIdx = tag.indexOf('#');
-        if (commentIdx > -1) {
-            smallestIdx = Math.min(commentIdx, smallestIdx);
-        }
-        // Avoid returning MAX_VALUE if none of these chars a present
-        if (spaceIdx + tabIdx + commentIdx == -3) {
-            return -1;
-        }
-        return smallestIdx;
-    }
-
     protected boolean changeIfDockerfileBaseImageLine(String imageToFind, String tag, StringBuilder stringBuilder, String line) {
         String trimmedLine = line.trim();
         List<String> lineParts = getLineParts(trimmedLine);

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -173,6 +173,21 @@ public class DockerfileGitHubUtil {
         return modified;
     }
 
+    /**
+     * This method will read a line and see if the line contains a FROM instruction with the specified
+     * <code>imageToFind</code>. If the image does not have the given <code>tag</code> then <code>stringBuilder</code>
+     * will get a modified version of the line with the new <code>tag</code>. We return <code>true</code> in this
+     * instance.
+     *
+     * If the inbound <code>line</code> does not qualify for changes or if the tag is already correct, the
+     * <code>stringBuilder</code> will get <code>line</code> added to it. We return <code>false</code> in this instance.
+     *
+     * @param imageToFind the Docker image that may require a tag update
+     * @param tag the Docker tag that we'd like the image to have
+     * @param stringBuilder the stringBuilder to accumulate the output lines for the pull request
+     * @param line the inbound line from the Dockerfile
+     * @return Whether we've modified the <code>line</code> that goes into <code>stringBuilder</code>
+     */
     protected boolean changeIfDockerfileBaseImageLine(String imageToFind, String tag, StringBuilder stringBuilder, String line) {
         String trimmedLine = line.trim();
         List<String> lineParts = getLineParts(trimmedLine);
@@ -181,7 +196,8 @@ public class DockerfileGitHubUtil {
         // Only check lines which contain a FROM instruction
         if (lineParts.size() >= 2 && lineParts.get(0).equals(Constants.FROM_INSTRUCTION)) {
             String originalTag = "";
-            String dockerFileImage = lineParts.get(1);
+            int imageLinePart = 1;
+            String dockerFileImage = lineParts.get(imageLinePart);
             String[] imageAndTag = dockerFileImage.split(":");
             String originalImage = imageAndTag[0];
 
@@ -190,11 +206,10 @@ public class DockerfileGitHubUtil {
                     originalTag = imageAndTag[1];
                 }
                 if (!originalTag.equals(tag)) {
-                    lineParts.set(1, originalImage + ":" + tag);
+                    lineParts.set(imageLinePart, originalImage + ":" + tag);
                     outputLine = String.join(" ", lineParts);
                     modified = true;
                 }
-
             }
         }
         stringBuilder.append(outputLine).append("\n");

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/FromInstructionTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/FromInstructionTest.java
@@ -11,14 +11,14 @@ public class FromInstructionTest {
     @DataProvider
     public Object[][] inputFormInstructionData() {
         return new Object[][]{
-                {"FROM dockerimage:3 # some comment", "FROM dockerimage:3 # some comment"},
-                {"FROM dockerimage:3 AS test", "FROM dockerimage:3 AS test"},
-                {"FROM dockerimage:3 \tAS \ttest # some comment", "FROM dockerimage:3 AS test # some comment"},
-                {"FROM    dockerimage:3#   some   comment", "FROM dockerimage:3 #   some   comment"},
-                {"        FROM       dockerimage   ", "FROM dockerimage"},
-                {"\t FROM \t dockerimage:4 \t #comment", "FROM dockerimage:4 #comment"},
-                {"FROM dockerimage:4:4:4 #comment", "FROM dockerimage:4 #comment"},
-                {"FROM dockerimage:4 #comment me # # ", "FROM dockerimage:4 #comment me # # "}
+                {"FROM dockerimage:3 # some comment",               "FROM dockerimage:3 # some comment"},
+                {"FROM dockerimage:3 AS test",                      "FROM dockerimage:3 AS test"},
+                {"FROM dockerimage:3 \tAS \ttest # some comment",   "FROM dockerimage:3 AS test # some comment"},
+                {"FROM    dockerimage:3#   some   comment",         "FROM dockerimage:3 #   some   comment"},
+                {"        FROM       dockerimage   ",               "FROM dockerimage"},
+                {"\t FROM \t dockerimage:4 \t #comment",            "FROM dockerimage:4 #comment"},
+                {"FROM dockerimage:4:4:4 #comment",                 "FROM dockerimage:4 #comment"},
+                {"FROM dockerimage:4 #comment me # # ",             "FROM dockerimage:4 #comment me # # "}
         };
     }
 
@@ -30,13 +30,15 @@ public class FromInstructionTest {
     @DataProvider
     public Object[][] isFromInstructionData() {
         return new Object[][]{
-                {"FROM dockerimage:3 # some comment", true},
+                {"FROM dockerimage:3 # some comment",       true},
                 {"FROM    dockerimage:3#   some   comment", true},
-                {"        FROM       dockerimage   ", true},
-                {"RUN something", false},
-                {"", false},
-                {"      ", false},
-                {null, false},
+                {"#FROM dockerimage:3",                     false},
+                {"# FROM dockerimage:3",                    false},
+                {"        FROM       dockerimage   ",       true},
+                {"RUN something",                           false},
+                {"",                                        false},
+                {"      ",                                  false},
+                {null,                                      false},
         };
     }
 
@@ -48,13 +50,13 @@ public class FromInstructionTest {
     @DataProvider
     public Object[][] baseImageNameData() {
         return new Object[][] {
-                {"FROM image:tag", "image"},
-                {"FROM image:tag\t", "image"},
-                {" \t FROM \t image:\t# comment", "image"},
-                {"FROM image:", "image"},
-                {"FROM image", "image"},
-                {"FROM", null},
-                {"FROM image:test # :comment", "image"}
+                {"FROM image:tag",                  "image"},
+                {"FROM image:tag\t",                "image"},
+                {" \t FROM \t image:\t# comment",   "image"},
+                {"FROM image:",                     "image"},
+                {"FROM image",                      "image"},
+                {"FROM",                            null},
+                {"FROM image:test # :comment",      "image"}
         };
     }
 
@@ -66,11 +68,11 @@ public class FromInstructionTest {
     @DataProvider
     public Object[][] hasBaseImageData() {
         return new Object[][] {
-                {"FROM image", "image", true},
+                {"FROM image", "image",                   true},
                 {"FROM registry.com/some/image", "image", true},
-                {"FROM image", null, false},
-                {"FROM", "something", false},
-                {"FROM", null, false}
+                {"FROM image", null,                      false},
+                {"FROM", "something",                     false},
+                {"FROM", null,                            false}
         };
     }
 
@@ -82,14 +84,14 @@ public class FromInstructionTest {
     @DataProvider
     public Object[][] tagData() {
         return new Object[][] {
-                {"FROM image:some-tag", "some-tag"},
+                {"FROM image:some-tag",                       "some-tag"},
                 {"FROM image:some-tag:with:weird:other:tags", "some-tag"},
-                {"FROM image", null},
-                {"FROM image:", null},
-                {"FROM image@some-digest", null},
-                {"FROM image# some comment", null},
-                {"FROM image:\tsome-tag # comment", null},
-                {"FROM image: some-tag # comment", null}
+                {"FROM image",                                null},
+                {"FROM image:",                               null},
+                {"FROM image@some-digest",                    null},
+                {"FROM image# some comment",                  null},
+                {"FROM image:\tsome-tag # comment",           null},
+                {"FROM image: some-tag # comment",            null}
         };
     }
 
@@ -101,10 +103,10 @@ public class FromInstructionTest {
     @DataProvider
     public Object[][] hasTagData() {
         return new Object[][] {
-                {"FROM no tag", false},
-                {"FROM image", false},
-                {"FROM image:", false},
-                {"FROM image:tag#as builder", true}
+                {"FROM no tag",                 false},
+                {"FROM image",                  false},
+                {"FROM image:",                 false},
+                {"FROM image:tag#as builder",   true}
         };
     }
 
@@ -116,14 +118,14 @@ public class FromInstructionTest {
     @DataProvider
     public Object[][] instructionWithNewTagData() {
         return new Object[][] {
-                {"FROM image:some-tag", "some-tag"},
-                {"FROM image:some-tag:with:weird:other:tags", "some-tag"},
-                {"FROM image", null},
-                {"FROM image:", null},
-                {"FROM image@some-digest", null},
-                {"FROM image# some comment", null},
-                {"FROM image:\tsome-tag # comment", null},
-                {"FROM image: some-tag # comment", null}
+                {"FROM image:some-tag",                         "some-tag"},
+                {"FROM image:some-tag:with:weird:other:tags",   "some-tag"},
+                {"FROM image",                                  null},
+                {"FROM image:",                                 null},
+                {"FROM image@some-digest",                      null},
+                {"FROM image# some comment",                    null},
+                {"FROM image:\tsome-tag # comment",             null},
+                {"FROM image: some-tag # comment",              null}
         };
     }
 
@@ -140,14 +142,14 @@ public class FromInstructionTest {
     @DataProvider
     public Object[][] hasADifferentTagData() {
         return new Object[][] {
-                {"FROM image:tag", "another", true},
-                {"FROM image:tag", "tag", false},
-                {"FROM image:tag", "", true},
-                {"FROM image:tag", null, true},
-                {"FROM image", null, false},
-                {"FROM image:", null, false},
-                {"FROM image: # comment", null, false},
-                {"FROM image: # comment", "tag", true}
+                {"FROM image:tag",          "another",  true},
+                {"FROM image:tag",          "tag",      false},
+                {"FROM image:tag",          "",         true},
+                {"FROM image:tag",          null,       true},
+                {"FROM image",              null,       false},
+                {"FROM image:",             null,       false},
+                {"FROM image: # comment",   null,       false},
+                {"FROM image: # comment",   "tag",      true}
         };
     }
 
@@ -159,15 +161,15 @@ public class FromInstructionTest {
     @DataProvider
     public Object[][] additionalPartsData() {
         return new Object[][] {
-                {"FROM image:tag as builder", ImmutableList.of("as", "builder")},
-                {"FROM image:tag as builder of things", ImmutableList.of("as", "builder", "of", "things")},
-                {"FROM image:tag#as builder", ImmutableList.of()},
-                {"FROM image:tag\t# comment", ImmutableList.of()},
-                {"FROM image:tag    \t# comment", ImmutableList.of()},
-                {"FROM image:tag  some\tother \t thing  \t# comment", ImmutableList.of("some", "other", "thing")},
-                {"FROM image:\t# comment # # # ", ImmutableList.of()},
-                {"FROM image:", ImmutableList.of()},
-                {"FROM", ImmutableList.of()}
+                {"FROM image:tag as builder",                           ImmutableList.of("as", "builder")},
+                {"FROM image:tag as builder of things",                 ImmutableList.of("as", "builder", "of", "things")},
+                {"FROM image:tag#as builder",                           ImmutableList.of()},
+                {"FROM image:tag\t# comment",                           ImmutableList.of()},
+                {"FROM image:tag    \t# comment",                       ImmutableList.of()},
+                {"FROM image:tag  some\tother \t thing  \t# comment",   ImmutableList.of("some", "other", "thing")},
+                {"FROM image:\t# comment # # # ",                       ImmutableList.of()},
+                {"FROM image:",                                         ImmutableList.of()},
+                {"FROM",                                                ImmutableList.of()}
         };
     }
 
@@ -179,13 +181,13 @@ public class FromInstructionTest {
     @DataProvider
     public Object[][] commentData() {
         return new Object[][] {
-                {"FROM image:tag as builder", null},
-                {"FROM image:tag#as builder", "#as builder"},
-                {"FROM image:tag # comment", "# comment"},
-                {"FROM image:tag\t# comment", "# comment"},
-                {"FROM image:\t# comment # # # ", "# comment # # # "},
-                {"FROM image:", null},
-                {"FROM image:test # :comment", "# :comment"}
+                {"FROM image:tag as builder",       null},
+                {"FROM image:tag#as builder",       "#as builder"},
+                {"FROM image:tag # comment",        "# comment"},
+                {"FROM image:tag\t# comment",       "# comment"},
+                {"FROM image:\t# comment # # # ",   "# comment # # # "},
+                {"FROM image:",                     null},
+                {"FROM image:test # :comment",      "# :comment"}
         };
     }
 
@@ -197,8 +199,8 @@ public class FromInstructionTest {
     @DataProvider
     public Object[][] hasCommentsData() {
         return new Object[][] {
-                {"FROM no comment", false},
-                {"FROM image:tag#as builder", true}
+                {"FROM no comment",             false},
+                {"FROM image:tag#as builder",   true}
         };
     }
 
@@ -212,6 +214,7 @@ public class FromInstructionTest {
         return new Object[][]{
                 {""},
                 {"RUN something"},
+                {"# FROM someimage"},
                 {":tag # comment"},
                 {null}
         };

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/FromInstructionTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/FromInstructionTest.java
@@ -1,0 +1,224 @@
+package com.salesforce.dockerfileimageupdate.model;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class FromInstructionTest {
+
+    @DataProvider
+    public Object[][] inputFormInstructionData() {
+        return new Object[][]{
+                {"FROM dockerimage:3 # some comment", "FROM dockerimage:3 # some comment"},
+                {"FROM dockerimage:3 AS test", "FROM dockerimage:3 AS test"},
+                {"FROM dockerimage:3 \tAS \ttest # some comment", "FROM dockerimage:3 AS test # some comment"},
+                {"FROM    dockerimage:3#   some   comment", "FROM dockerimage:3 #   some   comment"},
+                {"        FROM       dockerimage   ", "FROM dockerimage"},
+                {"\t FROM \t dockerimage:4 \t #comment", "FROM dockerimage:4 #comment"},
+                {"FROM dockerimage:4:4:4 #comment", "FROM dockerimage:4 #comment"},
+                {"FROM dockerimage:4 #comment me # # ", "FROM dockerimage:4 #comment me # # "}
+        };
+    }
+
+    @Test(dataProvider = "inputFormInstructionData")
+    public void testStringResult(String fromInstruction, String expectedResult) {
+        assertEquals(new FromInstruction(fromInstruction).toString(), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] isFromInstructionData() {
+        return new Object[][]{
+                {"FROM dockerimage:3 # some comment", true},
+                {"FROM    dockerimage:3#   some   comment", true},
+                {"        FROM       dockerimage   ", true},
+                {"RUN something", false},
+                {"", false},
+                {"      ", false},
+                {null, false},
+        };
+    }
+
+    @Test(dataProvider = "isFromInstructionData")
+    public void testLineToSplit(String input, boolean expectedResult) {
+        assertEquals(FromInstruction.isFromInstruction(input), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] baseImageNameData() {
+        return new Object[][] {
+                {"FROM image:tag", "image"},
+                {"FROM image:tag\t", "image"},
+                {" \t FROM \t image:\t# comment", "image"},
+                {"FROM image:", "image"},
+                {"FROM image", "image"},
+                {"FROM", null},
+                {"FROM image:test # :comment", "image"}
+        };
+    }
+
+    @Test(dataProvider = "baseImageNameData")
+    public void testBaseImageNameParsedCorrectly(String input, String expectedResult) {
+        assertEquals(new FromInstruction(input).getBaseImageName(), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] hasBaseImageData() {
+        return new Object[][] {
+                {"FROM image", "image", true},
+                {"FROM registry.com/some/image", "image", true},
+                {"FROM image", null, false},
+                {"FROM", "something", false},
+                {"FROM", null, false}
+        };
+    }
+
+    @Test(dataProvider = "hasBaseImageData")
+    public void testHasBaseImage(String fromInstruction, String imageToFind, boolean expectedResult) {
+        assertEquals(new FromInstruction(fromInstruction).hasBaseImage(imageToFind), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] tagData() {
+        return new Object[][] {
+                {"FROM image:some-tag", "some-tag"},
+                {"FROM image:some-tag:with:weird:other:tags", "some-tag"},
+                {"FROM image", null},
+                {"FROM image:", null},
+                {"FROM image@some-digest", null},
+                {"FROM image# some comment", null},
+                {"FROM image:\tsome-tag # comment", null},
+                {"FROM image: some-tag # comment", null}
+        };
+    }
+
+    @Test(dataProvider = "tagData")
+    public void testTagParsedCorrectly(String fromInstruction, String expectedResult) {
+        assertEquals(new FromInstruction(fromInstruction).getTag(), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] hasTagData() {
+        return new Object[][] {
+                {"FROM no tag", false},
+                {"FROM image", false},
+                {"FROM image:", false},
+                {"FROM image:tag#as builder", true}
+        };
+    }
+
+    @Test(dataProvider = "hasTagData")
+    public void testHasTag(String fromInstructions, boolean expectedResult) {
+        assertEquals(new FromInstruction(fromInstructions).hasTag(), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] instructionWithNewTagData() {
+        return new Object[][] {
+                {"FROM image:some-tag", "some-tag"},
+                {"FROM image:some-tag:with:weird:other:tags", "some-tag"},
+                {"FROM image", null},
+                {"FROM image:", null},
+                {"FROM image@some-digest", null},
+                {"FROM image# some comment", null},
+                {"FROM image:\tsome-tag # comment", null},
+                {"FROM image: some-tag # comment", null}
+        };
+    }
+
+    @Test(dataProvider = "instructionWithNewTagData")
+    public void testGetInstructionWithNewTag(String fromInstruction, String newTag) {
+        FromInstruction oldFromInstruction = new FromInstruction(fromInstruction);
+        FromInstruction newFromInstruction = oldFromInstruction.getFromInstructionWithNewTag(newTag);
+        assertEquals(newFromInstruction.getBaseImageName(), oldFromInstruction.getBaseImageName());
+        assertEquals(newFromInstruction.getComments(), oldFromInstruction.getComments());
+        assertEquals(newFromInstruction.getAdditionalParts(), oldFromInstruction.getAdditionalParts());
+        assertEquals(newFromInstruction.getTag(), newTag);
+    }
+
+    @DataProvider
+    public Object[][] hasADifferentTagData() {
+        return new Object[][] {
+                {"FROM image:tag", "another", true},
+                {"FROM image:tag", "tag", false},
+                {"FROM image:tag", "", true},
+                {"FROM image:tag", null, true},
+                {"FROM image", null, false},
+                {"FROM image:", null, false},
+                {"FROM image: # comment", null, false},
+                {"FROM image: # comment", "tag", true}
+        };
+    }
+
+    @Test(dataProvider = "hasADifferentTagData")
+    public void testHasADifferentTag(String fromInstruction, String tagToCheck, boolean expectedResult) {
+        assertEquals(new FromInstruction(fromInstruction).hasADifferentTag(tagToCheck), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] additionalPartsData() {
+        return new Object[][] {
+                {"FROM image:tag as builder", ImmutableList.of("as", "builder")},
+                {"FROM image:tag as builder of things", ImmutableList.of("as", "builder", "of", "things")},
+                {"FROM image:tag#as builder", ImmutableList.of()},
+                {"FROM image:tag\t# comment", ImmutableList.of()},
+                {"FROM image:tag    \t# comment", ImmutableList.of()},
+                {"FROM image:tag  some\tother \t thing  \t# comment", ImmutableList.of("some", "other", "thing")},
+                {"FROM image:\t# comment # # # ", ImmutableList.of()},
+                {"FROM image:", ImmutableList.of()},
+                {"FROM", ImmutableList.of()}
+        };
+    }
+
+    @Test(dataProvider = "additionalPartsData")
+    public void testAdditionalPartsParsedCorrectly(String input, ImmutableList expectedResult) {
+        assertEquals(new FromInstruction(input).getAdditionalParts(), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] commentData() {
+        return new Object[][] {
+                {"FROM image:tag as builder", null},
+                {"FROM image:tag#as builder", "#as builder"},
+                {"FROM image:tag # comment", "# comment"},
+                {"FROM image:tag\t# comment", "# comment"},
+                {"FROM image:\t# comment # # # ", "# comment # # # "},
+                {"FROM image:", null},
+                {"FROM image:test # :comment", "# :comment"}
+        };
+    }
+
+    @Test(dataProvider = "commentData")
+    public void testCommentsParsedCorrectly(String input, String expectedResult) {
+        assertEquals(new FromInstruction(input).getComments(), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] hasCommentsData() {
+        return new Object[][] {
+                {"FROM no comment", false},
+                {"FROM image:tag#as builder", true}
+        };
+    }
+
+    @Test(dataProvider = "hasCommentsData")
+    public void testHasComments(String fromInstructions, boolean expectedResult) {
+        assertEquals(new FromInstruction(fromInstructions).hasComments(), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] invalidData() {
+        return new Object[][]{
+                {""},
+                {"RUN something"},
+                {":tag # comment"},
+                {null}
+        };
+    }
+
+    @Test(dataProvider = "invalidData", expectedExceptions = IllegalArgumentException.class)
+    public void testInvalidFromData(String input) {
+        new FromInstruction(input);
+    }
+}

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -440,25 +440,6 @@ public class DockerfileGitHubUtilTest {
         assertEquals(strB.toString(), String.format("hello\n%s\nthis is a test\n", expectedReplacedData));
     }
 
-    @DataProvider
-    public Object[][] getEndOfTagLength() {
-        return new Object[][] {
-                { "tag as builder", 3},
-                { "tag#as builder", 3},
-                { "tag # comment", 3},
-                { "tag\t# comment", 3},
-                { "tag#\tcomment", 3},
-                { "", -1}
-        };
-    }
-
-    @Test(dataProvider = "getEndOfTagLength")
-    public void testGetEndOfTagLength(String tag, Integer expectedLen) {
-        gitHubUtil = mock(GitHubUtil.class);
-        dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
-        assertEquals(dockerfileGitHubUtil.getEndOfTagLength(tag), expectedLen.intValue());
-    }
-
     @Test
     public void testFindImagesAndFix_notModifiedPostData() throws Exception {
         gitHubUtil = mock(GitHubUtil.class);

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -524,24 +524,6 @@ public class DockerfileGitHubUtilTest {
     }
 
     @DataProvider
-    public Object[][] linesToSplitData() {
-        return new Object[][]{
-                {"FROM dockerimage:3 # some comment", Arrays.asList("FROM", "dockerimage:3", "# some comment")},
-                {"FROM    dockerimage:3      #   some   comment", Arrays.asList("FROM", "dockerimage:3", "#   some   comment")},
-                {"FROM    dockerimage:3#   some   comment", Arrays.asList("FROM", "dockerimage:3", "#   some   comment")},
-                {"FROM dockerimage", Arrays.asList("FROM", "dockerimage")},
-                {"FROM dockerimage # # # # # # # #  ", Arrays.asList("FROM", "dockerimage", "# # # # # # # #  ")},
-                {"RUN something", Arrays.asList("RUN", "something")},
-                {"", Collections.singletonList("")},
-        };
-    }
-
-    @Test(dataProvider = "linesToSplitData")
-    public void testLineToSplit(String input, List<String> expectedOutput) {
-        assertEquals(DockerfileGitHubUtil.getLineParts(input), expectedOutput);
-    }
-
-    @DataProvider
     public Object[][] inputStores() throws Exception {
         return new Object[][] {
                 {"{\n  \"images\": {\n" +

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -36,10 +36,10 @@ public class DockerfileGitHubUtilTest {
     @Mock
     GitHubUtil gitHubUtil;
 
-    DockerfileGitHubUtil dockerfileGitHubUtil;
+    private DockerfileGitHubUtil dockerfileGitHubUtil;
 
     @Test
-    public void testGetGithubUtil() throws Exception {
+    public void testGetGithubUtil() {
         gitHubUtil = mock(GitHubUtil.class);
         dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
         assertEquals(dockerfileGitHubUtil.getGitHubUtil(), gitHubUtil);
@@ -524,7 +524,7 @@ public class DockerfileGitHubUtilTest {
     }
 
     @DataProvider
-    public Object[][] linesToSplitData() throws Exception {
+    public Object[][] linesToSplitData() {
         return new Object[][]{
                 {"FROM dockerimage:3 # some comment", Arrays.asList("FROM", "dockerimage:3", "# some comment")},
                 {"FROM    dockerimage:3      #   some   comment", Arrays.asList("FROM", "dockerimage:3", "#   some   comment")},

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -413,6 +413,7 @@ public class DockerfileGitHubUtilTest {
                 { ":tag#as builder", "newtag", "FROM image:newtag #as builder"},
                 { ":tag # comment", "newtag", "FROM image:newtag # comment"},
                 { ":tag\t# comment", "newtag", "FROM image:newtag # comment"},
+                { ":tag\t# comment # # # ", "newtag", "FROM image:newtag # comment # # # "},
                 { ":", "newtag", "FROM image:newtag"},
                 { ":test # :comment", "newtag", "FROM image:newtag # :comment"}
         };
@@ -529,6 +530,7 @@ public class DockerfileGitHubUtilTest {
                 {"FROM    dockerimage:3      #   some   comment", Arrays.asList("FROM", "dockerimage:3", "#   some   comment")},
                 {"FROM    dockerimage:3#   some   comment", Arrays.asList("FROM", "dockerimage:3", "#   some   comment")},
                 {"FROM dockerimage", Arrays.asList("FROM", "dockerimage")},
+                {"FROM dockerimage # # # # # # # #  ", Arrays.asList("FROM", "dockerimage", "# # # # # # # #  ")},
                 {"RUN something", Arrays.asList("RUN", "something")},
                 {"", Collections.singletonList("")},
         };


### PR DESCRIPTION
Untagged images would be changed in the following manner:

`FROM some-image` -> `FROM some-image:5 some-image`

This change will no longer preserve whitespace before comments and will
simply delimit line parts by a space before a comment. Something like
this:

`FROM 	some-image   #   commented`

would become:

`FROM some-image:new-tag #   commented`

This feels like a reasonable compromise.