### PR TITLE
fix commit message generated for Dockerfile base updates

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -161,7 +161,7 @@ public class DockerfileGitHubUtil {
         boolean modified = rewriteDockerfile(img, tag, reader, strB);
         if (modified) {
             content.update(strB.toString(),
-                    "Fixed Dockerfile base image in /" + content.getPath() + ".\n" + customMessage, branch);
+                    "Fix Dockerfile base image in /" + content.getPath() + "\n\n" + customMessage, branch);
         }
     }
 


### PR DESCRIPTION
Commit message now conforms to widely accepted guidelines, as found on https://chris.beams.io/posts/git-commit (which is the top hit for "how to write a good commit message" on Google).  In particular:

  - subject is separated from the body with a blank line
  - subject line no longer ends with a period
  - subject line now uses imperative mood