### PR TITLE
Fix to avoid indefinite loop in case of failure to fork a repo

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Child.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Child.java
@@ -37,6 +37,11 @@ public class Child implements ExecutableWithNamespace {
         log.info("Retrieving repository and creating fork...");
         GHRepository repo = dockerfileGitHubUtil.getRepo(ns.get(Constants.GIT_REPO));
         GHRepository fork = dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(repo);
+        if (fork == null) {
+            log.info("Unable to fork {}. Please make sure that the repo is forkable.",
+                    repo.getFullName());
+            return;
+        }
 
         if (branch == null) {
             branch = repo.getDefaultBranch();

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
@@ -110,7 +110,7 @@ public class Parent implements ExecutableWithNamespace {
     protected Multimap<String, String> forkRepositoriesFoundAndGetPathToDockerfiles(PagedSearchIterable<GHContent> contentsWithImage) throws IOException {
         log.info("Forking repositories...");
         Multimap<String, String> pathToDockerfilesInParentRepo = HashMultimap.create();
-        List<String> parentReposForked = new ArrayList<>();
+        List<String> parentReposAlreadyChecked = new ArrayList<>();
         GHRepository parent;
         String parentRepoName = null;
         for (GHContent c : contentsWithImage) {
@@ -128,11 +128,15 @@ public class Parent implements ExecutableWithNamespace {
                         parentRepoName);
             } else {
                 pathToDockerfilesInParentRepo.put(parentRepoName, c.getPath());
-                // fork the parent if not already forked
-                if (!parentReposForked.contains(parentRepoName)) {
+                // fork the parent if not already forked or we couldn't fork
+                if (!parentReposAlreadyChecked.contains(parentRepoName)) {
                     log.info("Forking {}", parentRepoName);
-                    dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(parent);
-                    parentReposForked.add(parentRepoName);
+                    GHRepository fork = dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(parent);
+                    if (fork == null) {
+                        log.info("Could not fork {}", parentRepoName);
+                        pathToDockerfilesInParentRepo.remove(parentRepoName, c.getPath());
+                    }
+                    parentReposAlreadyChecked.add(parentRepoName);
                 }
             }
         }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java
@@ -64,7 +64,7 @@ public class GitHubUtil {
     /* Create a fork. Does not check if the fork is already there, because the fork will not be created if a fork
      * already exists.
      */
-    public GHRepository createFork(GHRepository repo) throws IOException {
+    public GHRepository createFork(GHRepository repo) {
         try {
             return repo.fork();
         } catch (IOException e) {
@@ -169,6 +169,7 @@ public class GitHubUtil {
                 String forkName = s.substring(s.lastIndexOf('/') + 1);
                 log.info(forkName);
                 if (!repoNamesSet.contains(forkName)) {
+                    log.debug("Forking is still in progress for {}" , forkName);
                     listOfReposHasRecentForks = false;
                 }
             }

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ChildTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ChildTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mockito;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
@@ -51,6 +52,7 @@ public class ChildTest {
         Namespace ns = new Namespace(inputMap);
         DockerfileGitHubUtil dockerfileGitHubUtil = Mockito.mock(DockerfileGitHubUtil.class);
         Mockito.when(dockerfileGitHubUtil.getRepo(Mockito.any())).thenReturn(new GHRepository());
+        Mockito.when(dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(Mockito.any())).thenReturn(new GHRepository());
         doNothing().when(dockerfileGitHubUtil).modifyAllOnGithub(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
         doNothing().when(dockerfileGitHubUtil).updateStore(anyString(), anyString(), anyString());
         doNothing().when(dockerfileGitHubUtil).createPullReq(Mockito.any(), anyString(), Mockito.any(), anyString());
@@ -59,5 +61,22 @@ public class ChildTest {
 
         Mockito.verify(dockerfileGitHubUtil, atLeastOnce())
                 .createPullReq(Mockito.any(), anyString(), Mockito.any(), anyString());
+    }
+
+    @Test
+    public void testCreateForkFailureCase_CreatePullReqIsSkipped() throws IOException, InterruptedException {
+        Child child = new Child();
+        Map<String, Object> nsMap = ImmutableMap.of(
+                GIT_REPO, "test",
+                IMG, "test",
+                FORCE_TAG, "test",
+                STORE, "test");
+        Namespace ns = new Namespace(nsMap);
+        DockerfileGitHubUtil dockerfileGitHubUtil = Mockito.mock(DockerfileGitHubUtil.class);
+        Mockito.when(dockerfileGitHubUtil.getRepo(Mockito.any())).thenReturn(new GHRepository());
+        Mockito.when(dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(Mockito.any())).thenReturn(null);
+        child.execute(ns, dockerfileGitHubUtil);
+        Mockito.verify(dockerfileGitHubUtil, Mockito.never()).createPullReq(Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.any());
     }
 }

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ParentTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ParentTest.java
@@ -99,6 +99,8 @@ public class ParentTest {
         when(contentsWithImageIterator.next()).thenReturn(content1, content2, content3, null);
         when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
 
+        when(dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(Mockito.any())).thenReturn(new GHRepository());
+
         Parent parent = new Parent();
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
         Multimap<String, String> repoMap =  parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);


### PR DESCRIPTION
Currently, if we fail to fork a repo we are just quietly catching the exception and not propagating the exception up. Because of this, before updating Dockerfiles and sending PRs, we may go into an indefinite loop waiting for the forking to complete. This PR contains fix to such cases.