### PR TITLE
Avoid infinite sleep loop if multiple fork names come back from GitHub API

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -113,15 +113,15 @@ public class All implements ExecutableWithNamespace {
                         parentRepoName);
             } else {
                 // fork the parent if not already forked
-                if (!parentReposForked.contains(parentRepoName)) {
+                if (parentReposForked.contains(parentRepoName) == false) {
                     GHRepository fork = dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(parent);
-                    if (fork != null) {
+                    if (fork == null) {
+                        log.info("Could not fork {}", parentRepoName);
+                    } else {
                         // Add repos to pathToDockerfilesInParentRepo and imagesFoundInParentRepo only if we forked it successfully.
                         pathToDockerfilesInParentRepo.put(parentRepoName, c.getPath());
                         imagesFoundInParentRepo.put(parentRepoName, image);
                         parentReposForked.add(parentRepoName);
-                    } else {
-                        log.info("Could not fork {}", parentRepoName);
                     }
                 }
             }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -95,7 +95,7 @@ public class All implements ExecutableWithNamespace {
                                          PagedSearchIterable<GHContent> contentsWithImage,
                                          String image) throws IOException {
         log.info("Forking {} repositories...", contentsWithImage.getTotalCount());
-        List<String> parentReposAlreadyChecked = new ArrayList<>();
+        List<String> parentReposForked = new ArrayList<>();
         GHRepository parent;
         String parentRepoName = null;
         for (GHContent c : contentsWithImage) {
@@ -112,17 +112,17 @@ public class All implements ExecutableWithNamespace {
                 log.warn("Skipping {} because it's a fork already. Sending a PR to a fork is unsupported at the moment.",
                         parentRepoName);
             } else {
-                pathToDockerfilesInParentRepo.put(parentRepoName, c.getPath());
-                imagesFoundInParentRepo.put(parentRepoName, image);
-
-                // fork the parent if not already forked or we couldn't fork
-                if (!parentReposAlreadyChecked.contains(parentRepoName)) {
+                // fork the parent if not already forked
+                if (!parentReposForked.contains(parentRepoName)) {
                     GHRepository fork = dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(parent);
-                    if (fork == null) {
+                    if (fork != null) {
+                        // Add repos to pathToDockerfilesInParentRepo and imagesFoundInParentRepo only if we forked it successfully.
+                        pathToDockerfilesInParentRepo.put(parentRepoName, c.getPath());
+                        imagesFoundInParentRepo.put(parentRepoName, image);
+                        parentReposForked.add(parentRepoName);
+                    } else {
                         log.info("Could not fork {}", parentRepoName);
-                        pathToDockerfilesInParentRepo.remove(parentRepoName, c.getPath());
                     }
-                    parentReposAlreadyChecked.add(parentRepoName);
                 }
             }
         }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
@@ -128,15 +128,15 @@ public class Parent implements ExecutableWithNamespace {
                         parentRepoName);
             } else {
                 // fork the parent if not already forked
-                if (!parentReposForked.contains(parentRepoName)) {
+                if (parentReposForked.contains(parentRepoName) == false) {
                     log.info("Forking {}", parentRepoName);
                     GHRepository fork = dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(parent);
-                    if (fork != null) {
+                    if (fork == null) {
+                        log.info("Could not fork {}", parentRepoName);
+                    } else {
                         // Add repos to pathToDockerfilesInParentRepo only if we forked it successfully.
                         pathToDockerfilesInParentRepo.put(parentRepoName, c.getPath());
                         parentReposForked.add(parentRepoName);
-                    } else {
-                        log.info("Could not fork {}", parentRepoName);
                     }
                 }
             }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
@@ -110,7 +110,7 @@ public class Parent implements ExecutableWithNamespace {
     protected Multimap<String, String> forkRepositoriesFoundAndGetPathToDockerfiles(PagedSearchIterable<GHContent> contentsWithImage) throws IOException {
         log.info("Forking repositories...");
         Multimap<String, String> pathToDockerfilesInParentRepo = HashMultimap.create();
-        List<String> parentReposAlreadyChecked = new ArrayList<>();
+        List<String> parentReposForked = new ArrayList<>();
         GHRepository parent;
         String parentRepoName = null;
         for (GHContent c : contentsWithImage) {
@@ -127,16 +127,17 @@ public class Parent implements ExecutableWithNamespace {
                 log.warn("Skipping {} because it's a fork already. Sending a PR to a fork is unsupported at the moment.",
                         parentRepoName);
             } else {
-                pathToDockerfilesInParentRepo.put(parentRepoName, c.getPath());
-                // fork the parent if not already forked or we couldn't fork
-                if (!parentReposAlreadyChecked.contains(parentRepoName)) {
+                // fork the parent if not already forked
+                if (!parentReposForked.contains(parentRepoName)) {
                     log.info("Forking {}", parentRepoName);
                     GHRepository fork = dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(parent);
-                    if (fork == null) {
+                    if (fork != null) {
+                        // Add repos to pathToDockerfilesInParentRepo only if we forked it successfully.
+                        pathToDockerfilesInParentRepo.put(parentRepoName, c.getPath());
+                        parentReposForked.add(parentRepoName);
+                    } else {
                         log.info("Could not fork {}", parentRepoName);
-                        pathToDockerfilesInParentRepo.remove(parentRepoName, c.getPath());
                     }
-                    parentReposAlreadyChecked.add(parentRepoName);
                 }
             }
         }

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ParentTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ParentTest.java
@@ -110,6 +110,58 @@ public class ParentTest {
     }
 
     @Test
+    public void forkRepositoriesFoundAndGetPathToDockerfiles_unableToforkRepo() throws Exception {
+        /**
+         * Suppose we have multiple dockerfiles that need to updated in a repo and we fail to fork such repo,
+         * we should not add those repos to pathToDockerfilesInParentRepo.
+         *
+         * Note: Sometimes GitHub search API returns the same result twice. This test covers such cases as well.
+         */
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+
+        GHRepository contentRepo1 = mock(GHRepository.class);
+        when(contentRepo1.getFullName()).thenReturn("1");
+
+        GHRepository duplicateContentRepo1 = mock(GHRepository.class);
+        // Say we have multiple dockerfiles to be updated in repo "1"
+        // Or sometimes GitHub search API returns same result twice.
+        when(duplicateContentRepo1.getFullName()).thenReturn("1");
+
+        GHRepository contentRepo2 = mock(GHRepository.class);
+        when(contentRepo2.getFullName()).thenReturn("2");
+
+        GHContent content1 = mock(GHContent.class);
+        when(content1.getOwner()).thenReturn(contentRepo1);
+        when(content1.getPath()).thenReturn("1"); // path to 1st dockerfile in repo "1"
+
+        GHContent content2 = mock(GHContent.class);
+        when(content2.getOwner()).thenReturn(duplicateContentRepo1);
+        when(content2.getPath()).thenReturn("2"); // path to 2st dockerfile in repo "1"
+
+        GHContent content3 = mock(GHContent.class);
+        when(content3.getOwner()).thenReturn(contentRepo2);
+        when(content3.getPath()).thenReturn("3");
+
+        PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
+
+        PagedIterator<GHContent> contentsWithImageIterator = mock(PagedIterator.class);
+        when(contentsWithImageIterator.hasNext()).thenReturn(true, true, true, false);
+        when(contentsWithImageIterator.next()).thenReturn(content1, content2, content3, null);
+        when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
+        when(dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(contentRepo1)).thenReturn(null); // repo1 is unforkable
+        when(dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(duplicateContentRepo1)).thenReturn(null); // repo1 is unforkable
+        when(dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(contentRepo2)).thenReturn(new GHRepository());
+
+        Parent parent = new Parent();
+        parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
+        Multimap<String, String> repoMap =  parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
+
+        // Since repo "1" is unforkable, we will only try to update repo "2"
+        verify(dockerfileGitHubUtil, times(3)).closeOutdatedPullRequestAndFork(any());
+        assertEquals(repoMap.size(), 1);
+    }
+
+    @Test
     public void testForkRepositoriesFound_forkRepoIsSkipped() throws Exception {
         DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
 


### PR DESCRIPTION
When we try to fork a repo and fail for some reason, we were still adding that repo to [parentReposAlreadyChecked](https://github.com/salesforce/dockerfile-image-update/blob/362eab5d527131f6d588fb7a4ce36abd176c4fae/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java#L113) as it would help us to avoid trying to create a fork and failing multiple times, when we are updating multiple Dockerfiles in the same repository. But this is not completely correct as we add the `(repo, dockerfile)` first to [pathToDockerfilesInParentRepo](https://github.com/salesforce/dockerfile-image-update/blob/362eab5d527131f6d588fb7a4ce36abd176c4fae/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java#L130) and then we check. Consider the following case:

If [contentsWithImage](https://github.com/salesforce/dockerfile-image-update/blob/362eab5d527131f6d588fb7a4ce36abd176c4fae/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java#L116) is `['seanhuitest/helloworld-docker-child', 'vmidde/helloworld-docker-child', 'vmidde/helloworld-docker-child',]`. In this case we have two Dockerfiles in `vmidde/helloworld-docker-child` repository which needs to be updated. Also assume that `vmidde/helloworld-docker-child` is unforkable.

In this case, when we first [visit `vmidde/helloworld-docker-child` while iterating](https://github.com/salesforce/dockerfile-image-update/blob/362eab5d527131f6d588fb7a4ce36abd176c4fae/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java#L116) we add and remove `vmidde/helloworld-docker-child` from [pathToDockerfilesInParentRepo](https://github.com/salesforce/dockerfile-image-update/blob/362eab5d527131f6d588fb7a4ce36abd176c4fae/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java#L112). In the same iteration we also add `vmidde/helloworld-docker-child` to [parentReposAlreadyChecked](https://github.com/salesforce/dockerfile-image-update/blob/362eab5d527131f6d588fb7a4ce36abd176c4fae/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java#L139). When we [visit `vmidde/helloworld-docker-child` for the second time,](https://github.com/salesforce/dockerfile-image-update/blob/362eab5d527131f6d588fb7a4ce36abd176c4fae/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java#L116) we first add `vmidde/helloworld-docker-child` to [pathToDockerfilesInParentRepo](https://github.com/salesforce/dockerfile-image-update/blob/362eab5d527131f6d588fb7a4ce36abd176c4fae/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java#L130) and we never remove it because it is already checked in the previous iteration.

To fix this issue, I'm simply not adding a repo to [parentReposAlreadyChecked](https://github.com/salesforce/dockerfile-image-update/blob/362eab5d527131f6d588fb7a4ce36abd176c4fae/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java#L139) if we are unable to fork the repo.

