### PR TITLE
Fix for updater missing sending PRs for few repos

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -61,7 +61,7 @@ public class All implements ExecutableWithNamespace {
         }
 
         log.info("Retrieving all the forks...");
-        PagedIterable<GHRepository> listOfCurrUserRepos =
+        List<GHRepository> listOfCurrUserRepos =
                 dockerfileGitHubUtil.getGHRepositories(pathToDockerfilesInParentRepo, currentUser);
 
         List<IOException> exceptions = new ArrayList<>();

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
@@ -175,6 +175,7 @@ public class Parent implements ExecutableWithNamespace {
                 return;
             }
         } else {
+            log.info("Skipping repo {} as it is not a fork.", currUserRepo.getFullName());
             return;
         }
         GHRepository parent = forkedRepo.getParent();

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
@@ -53,7 +53,7 @@ public class Parent implements ExecutableWithNamespace {
             throw new IOException("Could not retrieve authenticated user.");
         }
 
-        PagedIterable<GHRepository> listOfCurrUserRepos =
+        List<GHRepository> listOfCurrUserRepos =
                 dockerfileGitHubUtil.getGHRepositories(pathToDockerfilesInParentRepo, currentUser);
 
         List<IOException> exceptions = new ArrayList<>();

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -95,7 +95,7 @@ public class DockerfileGitHubUtil {
      *
      * Instead, we wait for 60 seconds if the list retrieved is not the list we want.
      */
-    public PagedIterable<GHRepository> getGHRepositories(Multimap<String, String> pathToDockerfileInParentRepo,
+    public List<GHRepository> getGHRepositories(Multimap<String, String> pathToDockerfileInParentRepo,
                                                             GHMyself currentUser) throws InterruptedException {
         return gitHubUtil.getGHRepositories(pathToDockerfileInParentRepo, currentUser);
     }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java
@@ -181,8 +181,8 @@ public class GitHubUtil {
     }
 
     /**
-     * Returns a <code>java.util.Map</code> of GitHub repositories owned by a user. Returned map contains repository names
-     * mapped to their corresponding GitHub repository objects.
+     * Returns a <code>java.util.Map</code> of GitHub repositories owned by a user. Returned Map's keys are the repository
+     * names and values are their corresponding GitHub repository objects.
      * @param user
      * @return
      */

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java
@@ -17,8 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -155,20 +154,18 @@ public class GitHubUtil {
      *
      * Instead, we wait for 60 seconds if the list retrieved is not the list we want.
      */
-    public PagedIterable<GHRepository> getGHRepositories(Multimap<String, String> pathToDockerfileInParentRepo,
-                                                         GHMyself currentUser) throws InterruptedException {
-        PagedIterable<GHRepository> listOfRepos;
-        Set<String> repoNamesSet = new HashSet<>();
+    public List<GHRepository> getGHRepositories(Multimap<String, String> pathToDockerfileInParentRepo,
+                                                 GHMyself currentUser) throws InterruptedException {
+        List<GHRepository> listOfRepos = new ArrayList<>();
         while (true) {
-            listOfRepos = currentUser.listRepositories(100, GHMyself.RepositoryListFilter.OWNER);
-            for (GHRepository repo : listOfRepos) {
-                repoNamesSet.add(repo.getName());
-            }
+            Map<String, GHRepository> repoByName = getReposForUserAtCurrentInstant(currentUser);
             boolean listOfReposHasRecentForks = true;
             for (String s : pathToDockerfileInParentRepo.keySet()) {
                 String forkName = s.substring(s.lastIndexOf('/') + 1);
                 log.info(String.format("Verifying that %s has been forked", forkName));
-                if (!repoNamesSet.contains(forkName)) {
+                if (repoByName.containsKey(forkName)) {
+                    listOfRepos.add(repoByName.get(forkName));
+                } else {
                     log.debug("Forking is still in progress for {}" , forkName);
                     listOfReposHasRecentForks = false;
                 }
@@ -180,7 +177,24 @@ public class GitHubUtil {
                 Thread.sleep(TimeUnit.MINUTES.toMillis(1));
             }
         }
-
         return listOfRepos;
+    }
+
+    /**
+     * Returns a <code>java.util.Map</code> of GitHub repositories owned by a user. Returned map contains repository names
+     * mapped to their corresponding GitHub repository objects.
+     * @param user
+     * @return
+     */
+    public Map<String, GHRepository> getReposForUserAtCurrentInstant(GHMyself user) {
+        Map<String, GHRepository> repoByName = new HashMap<>();
+        if (user == null) {
+            return repoByName;
+        }
+        PagedIterable<GHRepository> reposIterator = user.listRepositories(100, GHMyself.RepositoryListFilter.OWNER);
+        for (GHRepository repo: reposIterator) {
+            repoByName.put(repo.getName(), repo);
+        }
+        return repoByName;
     }
 }

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtilTest.java
@@ -212,4 +212,12 @@ public class GitHubUtilTest {
         assertTrue(repoByName.containsKey("test3") && repoByName.get("test3") == repo3);
         assertTrue(repoByName.containsKey("test4") && repoByName.get("test4") == repo4);
     }
+
+    @Test
+    public void testGetReposForUserAtCurrentInstantWithNullUser() throws Exception {
+        GitHub github = mock(GitHub.class);
+        GitHubUtil gitHubUtil = new GitHubUtil(github);
+        Map<String, GHRepository> repoByName = gitHubUtil.getReposForUserAtCurrentInstant(null);
+        assertTrue(repoByName.size() == 0);
+    }
 }


### PR DESCRIPTION
Sometimes updater is missing to send PRs to all the repos. To get the list of repositories updater uses `GHMyself.listRepositories()` method that returns a `PagedIterable<GHRepository>` closure. We loop through this `Iterable` to verify if all the forks were created and loop through the same `Iterable` again to send PRs. Sometimes if Git is flaky, `Iterable` fails to return all the repos in the second iteration and updater misses sending PRs to those repos. 