### PR TITLE
Use Docker: Travis JDK horribly out of date/buggy

### DIFF
--- a/.travis.deploy.sh
+++ b/.travis.deploy.sh
@@ -15,7 +15,7 @@ shred --remove codesigning.asc
 
 # Set up Maven settings and release
 cp .travis.settings.xml ${HOME}/.m2/settings.xml
-mvn releaser:release
+docker run -d --rm -v "$PWD":/usr/src/build -v "$HOME/.m2":/root/.m2  -v "$HOME/.ssh":/root/.ssh -v "$HOME/.gnupg":/root/.gnupg -v "$PWD/target:/usr/src/mymaven/target" -w /usr/src/build -e CI_DEPLOY_USER -e CI_DEPLOY_PASSWORD -e GPG_KEY_NAME -e GPG_PASSPHRASE maven:3.6-jdk-11 releaser:release
 
 # Push latest docker image
 set +x

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ branches:
   except:
   - "/^dockerfile-image-update-.*$/"
 script:
-- mvn --quiet --batch-mode verify
 - docker build -t salesforce/dockerfile-image-update .
 - echo git_api_token=${ITEST_GH_TOKEN} > `pwd`/itest.env
 - export user_itest_secrets_file_secret=`pwd`/itest.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
-FROM openjdk:8-alpine
+FROM maven:3.6-jdk-11 AS build
+
+COPY . .
+RUN mvn --version
+RUN mvn --quiet --batch-mode install
+
+FROM openjdk:11-jre-slim
 
 LABEL version="0.1"
 
 MAINTAINER dvastrata@salesforce.com
 
-ADD dockerfile-image-update/target/dockerfile-image-update-1.0-SNAPSHOT.jar /dockerfile-image-update.jar
+COPY --from=build /dockerfile-image-update/target/dockerfile-image-update-1.0-SNAPSHOT.jar /dockerfile-image-update.jar
 
 ENTRYPOINT ["java", "-jar", "/dockerfile-image-update.jar"]


### PR DESCRIPTION
Use a specific Docker image for both PRs as well as release. Release has been failing because of an old `11.0.2` JDK that they use. 