### PR TITLE
Use JDK/JRE 8 as before

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -110,4 +110,4 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           CI_DEPLOY_USER: ${{ secrets.CI_DEPLOY_USER }}
           CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
-        run: sh ./.ci.deploy.sh
+        run: make deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:11-jre-slim
+ARG JDK_VERSION
+FROM openjdk:${JDK_VERSION}-jre-slim
 
 LABEL version="0.1"
 

--- a/Dockerfile.maven
+++ b/Dockerfile.maven
@@ -1,4 +1,5 @@
-FROM maven:3.6-jdk-11 AS build
+ARG JDK_VERSION
+FROM maven:3.6-jdk-${JDK_VERSION} AS build
 
 COPY . .
 RUN mvn --version

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 all: mvn-docker-build get-itest-jar-from-maven-image integration-test
 
+# JDK_VERSION should be the JDK version we use to source our container dependencies
+JDK_VERSION=8
+
 DFIU_DIR=dockerfile-image-update
 DFIU_TARGET=${DFIU_DIR}/target
 DFIU_FULLPATH=${DFIU_TARGET}/dockerfile-image-update-1.0-SNAPSHOT.jar
@@ -8,10 +11,10 @@ DFIU_ITEST_TARGET=${DFIU_ITEST_DIR}/target
 DFIU_ITEST_FULLPATH=${DFIU_ITEST_TARGET}/dockerfile-image-update-itest-1.0-SNAPSHOT.jar
 
 mvn-docker-build:
-	docker build -t local-maven-build -f Dockerfile.maven .
+	docker build --tag local-maven-build --file Dockerfile.maven --build-arg JDK_VERSION=${JDK_VERSION} .
 	mkdir -p ${DFIU_TARGET}
 	docker run --rm -v $(CURDIR):/tmp/project local-maven-build /bin/bash -c "cp ${DFIU_FULLPATH} /tmp/project/${DFIU_FULLPATH}"
-	docker build -t salesforce/dockerfile-image-update .
+	docker build --tag salesforce/dockerfile-image-update --build-arg JDK_VERSION=${JDK_VERSION} .
 
 #TODO: Modify docker-compose.yml for local image
 #TODO: add --abort-on-container-exit to docker-compose once itests can be made not to flap see issue #21
@@ -27,3 +30,6 @@ get-main-project-dirs:
 get-itest-jar-from-maven-image:
 	mkdir -p ${DFIU_ITEST_TARGET}
 	docker run --rm -v $(CURDIR):/tmp/project local-maven-build /bin/bash -c "cp ${DFIU_ITEST_FULLPATH} /tmp/project/${DFIU_ITEST_FULLPATH}"
+
+deploy:
+	JDK_VERSION=${JDK_VERSION} ./.ci.deploy.sh

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/FromInstruction.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/FromInstruction.java
@@ -93,8 +93,8 @@ public class FromInstruction {
 
     /**
      * Get a new {@code FromInstruction} the same as this but with the {@code tag} set as {@code newTag}
-     * @param newTag
-     * @return
+     * @param newTag the new image tag
+     * @return a new FROM with the new image tag
      */
     public FromInstruction getFromInstructionWithNewTag(String newTag) {
         return new FromInstruction(baseImageName, newTag, additionalParts, comments);

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java
@@ -45,8 +45,8 @@ public class GitHubUtil {
      * paid account.
      *
      * @param repoName Name of the repository
-     * @return
-     * @throws IOException
+     * @return GHRepository for {@code repoName}
+     * @throws IOException when failing to get a GHRepository
      */
     public GHRepository createPublicRepo(String repoName) throws IOException {
         GHCreateRepositoryBuilder repoBuilder = github.createRepository(repoName);
@@ -183,8 +183,8 @@ public class GitHubUtil {
     /**
      * Returns a <code>java.util.Map</code> of GitHub repositories owned by a user. Returned Map's keys are the repository
      * names and values are their corresponding GitHub repository objects.
-     * @param user
-     * @return
+     * @param user GitHub user (person/org) which has repositories
+     * @return map of repo name to GHRepository
      */
     public Map<String, GHRepository> getReposForUserAtCurrentInstant(GHMyself user) {
         Map<String, GHRepository> repoByName = new HashMap<>();

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>3.2.0</version>
+                        <configuration>
+                            <source>8</source>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
The full CI didn't lock to a consistent JDK/JRE until recent GitHub
Actions work. When Travis moved to JDK 11, it brought sads when
generating javadoc. Instead of taking on a migration to a newer JDK and
introducing more modules stuff, locking to JDK/JRE 8 as before.

Improvements to this:
* Use a JDK_VERSION in Makefile to drive all container JDK/JRE
dependencies
* Put releaser:release on batch/quiet mode (could potentially just use
batch)
* Correct some Javadoc
* Tell Maven Javadoc plugin that we have level 8 source
* Check that all env vars are set in .ci.deploy.sh