### PR TITLE
Don't close forks, don't close PRs for child/parent commands

### DIFF
--- a/dockerfile-image-update-itest/src/main/java/com/salesforce/dockerfileimageupdate/itest/tests/ChildCommandTest.java
+++ b/dockerfile-image-update-itest/src/main/java/com/salesforce/dockerfileimageupdate/itest/tests/ChildCommandTest.java
@@ -109,7 +109,7 @@ public class ChildCommandTest {
             GHRepository storeRepo = github.getRepository(Paths.get(user, STORE_NAME).toString());
             GHContent store = storeRepo.getFileContent("store.json");
             try (InputStream stream = store.read(); InputStreamReader streamR = new InputStreamReader(stream)) {
-                    json = new JsonParser().parse(streamR);
+                    json = JsonParser.parseReader(streamR);
                     images = json.getAsJsonObject().get("images");
                     break;
             } catch (IllegalStateException e) {
@@ -129,7 +129,7 @@ public class ChildCommandTest {
     public void testAsUser() throws Exception {
         GHRepository repo = github.getOrganization(ORG).getRepository(NAME);
         List<GHPullRequest> prs = repo.getPullRequests(GHIssueState.OPEN);
-        Assert.assertTrue(prs.size() == 1);
+        Assert.assertEquals(prs.size(), 1);
         for (GHPullRequest pr : prs) {
             pr.merge("Automatic merge through itests.");
             pr.close();

--- a/dockerfile-image-update-itest/src/main/java/com/salesforce/dockerfileimageupdate/itest/tests/ParentCommandTest.java
+++ b/dockerfile-image-update-itest/src/main/java/com/salesforce/dockerfileimageupdate/itest/tests/ParentCommandTest.java
@@ -135,7 +135,7 @@ public class ParentCommandTest {
         String latestCommit = storeRepo.getBranches().get(storeRepo.getDefaultBranch()).getSHA1();
         GHContent store = storeRepo.getFileContent("store.json", latestCommit);
         try (InputStream stream = store.read(); InputStreamReader streamR = new InputStreamReader(stream)) {
-            JsonElement json = new JsonParser().parse(streamR);
+            JsonElement json = JsonParser.parseReader(streamR);
             assertNotNull(json);
             JsonElement images = json.getAsJsonObject().get("images");
             assertNotNull(images);

--- a/dockerfile-image-update-itest/src/main/java/com/salesforce/dockerfileimageupdate/itest/tests/TestValidationCommon.java
+++ b/dockerfile-image-update-itest/src/main/java/com/salesforce/dockerfileimageupdate/itest/tests/TestValidationCommon.java
@@ -77,7 +77,7 @@ public class TestValidationCommon {
         boolean bypassedDelay = false;
         for (int i = 0; i < 60; i++) {
             PagedSearchIterable<GHContent> searchImage1 = github.searchContent().
-                    language("Dockerfile").q(image).list();
+                    filename("Dockerfile").q(image).list();
             log.info("Currently {} search gives {} results. It should be {}.", imageName,
                     searchImage1.getTotalCount(), numberOfRepos);
             if (searchImage1.getTotalCount() >= 4) {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
@@ -53,7 +53,7 @@ public class CommandLine {
     }
 
     static ArgumentParser getArgumentParser() {
-        ArgumentParser parser = ArgumentParsers.newArgumentParser("dockerfile-image-update", true)
+        ArgumentParser parser = ArgumentParsers.newFor("dockerfile-image-update").addHelp(true).build()
                 .description("Image Updates through Pull Request Automator");
 
         parser.addArgument("-o", "--" + Constants.GIT_ORG)

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/GitForkBranch.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/GitForkBranch.java
@@ -1,0 +1,86 @@
+package com.salesforce.dockerfileimageupdate.model;
+
+// Converts an imageName to a branchName. Primary conversion necessary is : to -
+// Also support backward compatible method of specifying a branch
+//
+// Container name rules: https://docs.docker.com/engine/reference/commandline/tag/#extended-description
+// Branch Rules: https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html
+//
+public class GitForkBranch {
+    private final String branchPrefix;
+    private final String imageName;
+    private final String imageTag;
+    private final boolean specifiedBranchOverride;
+
+    public GitForkBranch(String imageName, String imageTag) {
+        this(imageName, imageTag, null);
+    }
+
+    public GitForkBranch(String imageName, String imageTag, String specifiedBranch) {
+        this.imageTag = (imageTag == null || imageTag.trim().isEmpty()) ? "" : imageTag.trim();
+        this.imageName = (imageName == null || imageName.trim().isEmpty()) ? "" : imageName.trim();
+        if (specifiedBranch == null || specifiedBranch.trim().isEmpty()) {
+            if (this.imageName.isEmpty()) {
+                throw new IllegalArgumentException("You must specify an imageName if not specifying a branch");
+            }
+            this.branchPrefix = this.imageName.replace(":", "-").toLowerCase();
+            this.specifiedBranchOverride = false;
+        } else {
+            this.branchPrefix = specifiedBranch;
+            this.specifiedBranchOverride = true;
+        }
+    }
+
+    /**
+     * If a specifiedBranch was specified, do a direct comparison. Otherwise, check for a
+     * translated imageName as a prefix.
+     *
+     * @param branchName branch name to check against our new image
+     * @return is the branch name equal to specifiedBranch or the normalized image name
+     */
+    public boolean isSameBranchOrHasImageNamePrefix(String branchName) {
+        if (this.imageTag == null) {
+            return this.getBranchName().equals(branchName);
+        } else if (branchName != null) {
+            String tempBranchName = branchName.trim();
+            return getBranchWithoutTag(tempBranchName).equals(this.branchPrefix);
+        }
+        return false;
+    }
+
+    private String getBranchWithoutTag(String branchName) {
+        int lastDash = branchName.lastIndexOf("-");
+        if (lastDash == -1) {
+            return branchName;
+        } else {
+            return branchName.substring(0, lastDash);
+        }
+    }
+
+    /**
+     * @return a branch was specified to override default behavior
+     */
+    public boolean useSpecifiedBranchOverride() {
+        return this.specifiedBranchOverride;
+    }
+
+    /**
+     * Either the specified branch of a combo of normalized imageName-imageTag
+     * @return
+     */
+    public String getBranchName() {
+        if (this.imageTag == null || this.imageTag.trim().isEmpty()) {
+            return this.branchPrefix;
+        } else {
+            return this.branchPrefix + "-" + this.imageTag;
+        }
+    }
+
+    public String getImageName() {
+        return imageName;
+    }
+
+    public String getImageTag() {
+        return imageTag;
+    }
+}

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/GitForkBranch.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/GitForkBranch.java
@@ -1,20 +1,17 @@
 package com.salesforce.dockerfileimageupdate.model;
 
-// Converts an imageName to a branchName. Primary conversion necessary is : to -
-// Also support backward compatible method of specifying a branch
-//
-// Container name rules: https://docs.docker.com/engine/reference/commandline/tag/#extended-description
-// Branch Rules: https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html
-//
+/**
+ * Converts an imageName to a branchName. Primary conversion necessary is : to -
+ * Also support backward compatible method of specifying a branch
+ *
+ * Container name rules: https://docs.docker.com/engine/reference/commandline/tag/#extended-description
+ * Branch Rules: https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html
+ */
 public class GitForkBranch {
     private final String branchPrefix;
     private final String imageName;
     private final String imageTag;
     private final boolean specifiedBranchOverride;
-
-    public GitForkBranch(String imageName, String imageTag) {
-        this(imageName, imageTag, null);
-    }
 
     public GitForkBranch(String imageName, String imageTag, String specifiedBranch) {
         this.imageTag = (imageTag == null || imageTag.trim().isEmpty()) ? "" : imageTag.trim();
@@ -65,8 +62,12 @@ public class GitForkBranch {
     }
 
     /**
-     * Either the specified branch of a combo of normalized imageName-imageTag
-     * @return
+     * Either the specified branch or a combo of normalized imageName-imageTag
+     *
+     * This essentially uses a cleansed and lowercase imageName as the branch prefix.
+     * If an imageTag exists, we append a dash and then the imageTag.
+     *
+     * @return cleansed branchPrefix[-imageTag]
      */
     public String getBranchName() {
         if (this.imageTag == null || this.imageTag.trim().isEmpty()) {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/GitForkBranch.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/GitForkBranch.java
@@ -39,7 +39,7 @@ public class GitForkBranch {
      * @return is the branch name equal to specifiedBranch or the normalized image name
      */
     public boolean isSameBranchOrHasImageNamePrefix(String branchName) {
-        if (this.imageTag == null) {
+        if (this.imageTag.equals("")) {
             return this.getBranchName().equals(branchName);
         } else if (branchName != null) {
             String tempBranchName = branchName.trim();

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/GitHubContentToProcess.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/GitHubContentToProcess.java
@@ -1,0 +1,35 @@
+package com.salesforce.dockerfileimageupdate.model;
+
+import org.kohsuke.github.GHRepository;
+
+/**
+ * Models the fork, parent repo, and contentPath of content in GitHub to process for an update operation
+ */
+public class GitHubContentToProcess {
+    private final GHRepository fork;
+    private final GHRepository parent;
+    private final String contentPath;
+
+    public GitHubContentToProcess(GHRepository fork, GHRepository parent, String contentPath) {
+        this.parent = parent;
+        this.fork = fork;
+        this.contentPath = contentPath;
+    }
+
+    public GHRepository getFork() {
+        return fork;
+    }
+
+    public GHRepository getParent() {
+        return parent;
+    }
+
+    public String getContentPath() {
+        return contentPath;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("content path: %s; fork: %s", contentPath, fork);
+    }
+}

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/GitHubPullRequestSender.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/GitHubPullRequestSender.java
@@ -89,19 +89,20 @@ public class GitHubPullRequestSender {
      * @param parentRepo The parent repo which may or may not be a candidate to fork
      */
     protected Optional<String> shouldNotForkRepo(GHRepository parentRepo) {
+        Optional<String> result = Optional.empty();
         if (parentRepo.isFork()) {
-            return Optional.of(REPO_IS_FORK);
-        }
-        if (parentRepo.isArchived()) {
-            return Optional.of(REPO_IS_ARCHIVED);
-        }
-        try {
-            if (dockerfileGitHubUtil.thisUserIsOwner(parentRepo)) {
-                return Optional.of(REPO_IS_OWNED_BY_THIS_USER);
+            result = Optional.of(REPO_IS_FORK);
+        } else if (parentRepo.isArchived()) {
+            result = Optional.of(REPO_IS_ARCHIVED);
+        } else {
+            try {
+                if (dockerfileGitHubUtil.thisUserIsOwner(parentRepo)) {
+                    result = Optional.of(REPO_IS_OWNED_BY_THIS_USER);
+                }
+            } catch (IOException ioException) {
+                result = Optional.of(COULD_NOT_CHECK_THIS_USER);
             }
-        } catch (IOException ioException) {
-            return Optional.of(COULD_NOT_CHECK_THIS_USER);
         }
-        return Optional.empty();
+        return result;
     }
 }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/GitHubPullRequestSender.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/GitHubPullRequestSender.java
@@ -1,0 +1,87 @@
+package com.salesforce.dockerfileimageupdate.process;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.salesforce.dockerfileimageupdate.model.GitHubContentToProcess;
+import com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil;
+import org.kohsuke.github.GHContent;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.PagedSearchIterable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Optional;
+
+public class GitHubPullRequestSender {
+    private static final Logger log = LoggerFactory.getLogger(GitHubPullRequestSender.class);
+    private final DockerfileGitHubUtil dockerfileGitHubUtil;
+
+    public GitHubPullRequestSender(DockerfileGitHubUtil dockerfileGitHubUtil) {
+        this.dockerfileGitHubUtil = dockerfileGitHubUtil;
+    }
+
+    /* There is a separation here with forking and performing the Dockerfile update. This is because of the delay
+     * on Github, where after the fork, there may be a time gap between repository creation and content replication
+     * when forking. So, in hopes of alleviating the situation a little bit, we do all the forking before the
+     * Dockerfile updates.
+     *
+     * NOTE: We are not currently forking repositories that are already forks
+     */
+    public Multimap<String, GitHubContentToProcess> forkRepositoriesFoundAndGetPathToDockerfiles(PagedSearchIterable<GHContent> contentsWithImage) throws IOException {
+        log.info("Forking repositories...");
+        Multimap<String, GitHubContentToProcess> pathToDockerfilesInParentRepo = HashMultimap.create();
+        GHRepository parent;
+        String parentRepoName;
+        for (GHContent c : contentsWithImage) {
+            /* Kohsuke's GitHub API library, when retrieving the forked repository, looks at the name of the parent to
+             * retrieve. The issue with that is: GitHub, when forking two or more repositories with the same name,
+             * automatically fixes the names to be unique (by appending "-#" to the end). Because of this edge case, we
+             * cannot save the forks and iterate over the repositories; else, we end up missing/not updating the
+             * repositories that were automatically fixed by GitHub. Instead, we save the names of the parent repos
+             * in the map above, find the list of repositories under the authorized user, and iterate through that list.
+             */
+            parent = c.getOwner();
+            parentRepoName = parent.getFullName();
+            // TODO: Error check... Refresh the repo to ensure that the object has full details
+            parent = dockerfileGitHubUtil.getRepo(parentRepoName);
+            if (parent.isFork()) {
+                log.warn("Skipping {} because it's a fork already. Sending a PR to a fork is unsupported at the moment.",
+                        parentRepoName);
+            } else if (parent.isArchived()) {
+                log.warn("Skipping {} because it's archived.", parent.getFullName());
+            } else if (dockerfileGitHubUtil.thisUserIsOwner(parent)) {
+                log.warn("Skipping {} because it is owned by this user.", parent.getFullName());
+            } else {
+                // fork the parent if not already forked
+                GHRepository fork;
+                if (pathToDockerfilesInParentRepo.containsKey(parentRepoName)) {
+                    // Found more content for this fork, so add it as well
+                    Collection<GitHubContentToProcess> gitHubContentToProcesses = pathToDockerfilesInParentRepo.get(parentRepoName);
+                    Optional<GitHubContentToProcess> firstForkData = gitHubContentToProcesses.stream().findFirst();
+                    if (firstForkData.isPresent()) {
+                        fork = firstForkData.get().getFork();
+                        pathToDockerfilesInParentRepo.put(parentRepoName, new GitHubContentToProcess(fork, parent, c.getPath()));
+                    } else {
+                        log.warn("For some reason we have ");
+                    }
+                } else {
+                    log.info("Getting or creating fork: {}", parentRepoName);
+                    fork = dockerfileGitHubUtil.getOrCreateFork(parent);
+//                    fork = null;
+                    if (fork == null) {
+                        log.info("Could not fork {}", parentRepoName);
+                    } else {
+                        // Add repos to pathToDockerfilesInParentRepo only if we forked it successfully.
+                        pathToDockerfilesInParentRepo.put(parentRepoName, new GitHubContentToProcess(fork, parent, c.getPath()));
+                    }
+                }
+            }
+        }
+
+        log.info("Path to Dockerfiles in repos: {}", pathToDockerfilesInParentRepo);
+
+        return pathToDockerfilesInParentRepo;
+    }
+}

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/GitHubPullRequestSender.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/GitHubPullRequestSender.java
@@ -68,7 +68,7 @@ public class GitHubPullRequestSender {
                     }
                 } else {
                     log.info("Getting or creating fork: {}", parentRepoName);
-                    fork = dockerfileGitHubUtil.getOrCreateFork(parent); //CATCH IOException
+                    fork = dockerfileGitHubUtil.getOrCreateFork(parent);
                     if (fork == null) {
                         log.info("Could not fork {}", parentRepoName);
                     } else {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/repository/GitHub.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/repository/GitHub.java
@@ -1,0 +1,22 @@
+package com.salesforce.dockerfileimageupdate.repository;
+
+import com.google.common.collect.Multimap;
+import com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil;
+import org.kohsuke.github.GHRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GitHub {
+    private static final Logger log = LoggerFactory.getLogger(DockerfileGitHubUtil.class);
+
+    public static boolean shouldNotProcessDockerfilesInRepo(Multimap<String, String> pathToDockerfilesInParentRepo, GHRepository parent) {
+        if (parent == null || !pathToDockerfilesInParentRepo.containsKey(parent.getFullName()) || parent.isArchived()) {
+            if (parent != null && parent.isArchived()) {
+                log.info("Skipping archived repo: {}", parent.getFullName());
+            }
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/repository/GitHub.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/repository/GitHub.java
@@ -1,14 +1,20 @@
 package com.salesforce.dockerfileimageupdate.repository;
 
 import com.google.common.collect.Multimap;
-import com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil;
 import org.kohsuke.github.GHRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class GitHub {
-    private static final Logger log = LoggerFactory.getLogger(DockerfileGitHubUtil.class);
+    private static final Logger log = LoggerFactory.getLogger(GitHub.class);
 
+    /**
+     * Check to see if we found Dockerfiles that need processing in the provided repository and that it isn't archived
+     *
+     * @param pathToDockerfilesInParentRepo map of dockerfile repos to process
+     * @param parent repository to check
+     * @return is the parent in the list, valid, and not archived?
+     */
     public static boolean shouldNotProcessDockerfilesInRepo(Multimap<String, String> pathToDockerfilesInParentRepo, GHRepository parent) {
         if (parent == null || !pathToDockerfilesInParentRepo.containsKey(parent.getFullName()) || parent.isArchived()) {
             if (parent != null && parent.isArchived()) {
@@ -18,5 +24,4 @@ public class GitHub {
         }
         return false;
     }
-
 }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/storage/GitHubJsonStore.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/storage/GitHubJsonStore.java
@@ -1,0 +1,91 @@
+package com.salesforce.dockerfileimageupdate.storage;
+
+import com.google.gson.*;
+import com.salesforce.dockerfileimageupdate.utils.Constants;
+import com.salesforce.dockerfileimageupdate.utils.GitHubUtil;
+import org.kohsuke.github.GHContent;
+import org.kohsuke.github.GHMyself;
+import org.kohsuke.github.GHRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Paths;
+
+public class GitHubJsonStore {
+    private static final Logger log = LoggerFactory.getLogger(GitHubJsonStore.class);
+    private final GitHubUtil gitHubUtil;
+    private final String store;
+
+    public GitHubJsonStore(GitHubUtil gitHubUtil, String store) {
+        this.gitHubUtil = gitHubUtil;
+        this.store = store;
+    }
+
+    /* The store link should be a repository name on Github. */
+    public void updateStore(String img, String tag) throws IOException {
+        if (store == null) {
+            log.info("Image tag store cannot be null. Skipping store update...");
+            return;
+        }
+        log.info("Updating store: {} with image: {} tag: {}...", store, img, tag);
+        GHRepository storeRepo;
+        try {
+            GHMyself myself = gitHubUtil.getMyself();
+            String ownerOrg = myself.getLogin();
+            storeRepo = gitHubUtil.getRepo(Paths.get(ownerOrg, store).toString());
+        } catch (IOException e) {
+            storeRepo = gitHubUtil.createPublicRepo(store);
+        }
+        updateStoreOnGithub(storeRepo, Constants.STORE_JSON_FILE, img, tag);
+    }
+
+    protected void updateStoreOnGithub(GHRepository repo, String path, String img, String tag) throws IOException {
+        try {
+            repo.getFileContent(path);
+        } catch (IOException e) {
+            repo.createContent().content("").message("initializing store").path(path).commit();
+        }
+
+        String latestCommit = repo.getBranches().get(repo.getDefaultBranch()).getSHA1();
+        log.info("Loading image store at commit {}", latestCommit);
+        GHContent content = repo.getFileContent(path, latestCommit);
+
+        if (content.isFile()) {
+            JsonElement json;
+            try (InputStream stream = content.read(); InputStreamReader streamR = new InputStreamReader(stream)) {
+                try {
+                    json = new JsonParser().parse(streamR);
+                } catch (JsonParseException e) {
+                    log.warn("Not a JSON format store. Clearing and rewriting as JSON...");
+                    json = JsonNull.INSTANCE;
+                }
+            }
+            String jsonOutput = getAndModifyJsonString(json, img, tag);
+            content.update(jsonOutput,
+                    String.format("Updated image %s with tag %s.\n@rev none@", img, tag), repo.getDefaultBranch());
+        }
+    }
+
+    protected String getAndModifyJsonString(JsonElement json, String img, String tag) {
+        JsonElement images;
+        if (json.isJsonNull()) {
+            json = new JsonObject();
+            images = new JsonObject();
+            json.getAsJsonObject().add("images", images);
+        }
+        images = json.getAsJsonObject().get("images");
+        if (images == null) {
+            images = new JsonObject();
+            json.getAsJsonObject().add("images", images);
+            images = json.getAsJsonObject().get("images");
+        }
+        JsonElement newTag = new JsonPrimitive(tag);
+        images.getAsJsonObject().add(img, newTag);
+
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        return gson.toJson(json);
+    }
+}

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/storage/GitHubJsonStore.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/storage/GitHubJsonStore.java
@@ -57,7 +57,7 @@ public class GitHubJsonStore {
             JsonElement json;
             try (InputStream stream = content.read(); InputStreamReader streamR = new InputStreamReader(stream)) {
                 try {
-                    json = new JsonParser().parse(streamR);
+                    json = JsonParser.parseReader(streamR);
                 } catch (JsonParseException e) {
                     log.warn("Not a JSON format store. Clearing and rewriting as JSON...");
                     json = JsonNull.INSTANCE;

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -19,7 +19,10 @@ import com.salesforce.dockerfileimageupdate.subcommands.ExecutableWithNamespace;
 import com.salesforce.dockerfileimageupdate.utils.Constants;
 import com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil;
 import net.sourceforge.argparse4j.inf.Namespace;
-import org.kohsuke.github.*;
+import org.kohsuke.github.GHContent;
+import org.kohsuke.github.GHMyself;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.PagedSearchIterable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,8 +117,9 @@ public class All implements ExecutableWithNamespace {
                         parentRepoName);
             } else {
                 // fork the parent if not already forked
-                if (parentReposForked.contains(parentRepoName) == false) {
-                    GHRepository fork = dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(parent);
+                if (!parentReposForked.contains(parentRepoName)) {
+                    // TODO: Need to close PR!
+                    GHRepository fork = dockerfileGitHubUtil.getOrCreateFork(parent);
                     if (fork == null) {
                         log.info("Could not fork {}", parentRepoName);
                     } else {
@@ -148,7 +152,7 @@ public class All implements ExecutableWithNamespace {
         JsonElement json;
         try (InputStream stream = storeContent.read(); InputStreamReader streamR = new InputStreamReader(stream)) {
             try {
-                json = new JsonParser().parse(streamR);
+                json = JsonParser.parseReader(streamR);
             } catch (JsonParseException e) {
                 log.warn("Not a JSON format store.");
                 return Collections.emptySet();

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -14,6 +14,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import com.salesforce.dockerfileimageupdate.SubCommand;
+import com.salesforce.dockerfileimageupdate.repository.GitHub;
 import com.salesforce.dockerfileimageupdate.subcommands.ExecutableWithNamespace;
 import com.salesforce.dockerfileimageupdate.utils.Constants;
 import com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil;
@@ -114,7 +115,7 @@ public class All implements ExecutableWithNamespace {
             } else {
                 // fork the parent if not already forked
                 if (parentReposForked.contains(parentRepoName) == false) {
-                    GHRepository fork = dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(parent);
+                    GHRepository fork = dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(parent);
                     if (fork == null) {
                         log.info("Could not fork {}", parentRepoName);
                     } else {
@@ -191,12 +192,7 @@ public class All implements ExecutableWithNamespace {
         }
         GHRepository parent = forkedRepo.getParent();
 
-        if (parent == null || !pathToDockerfilesInParentRepo.containsKey(parent.getFullName()) || parent.isArchived()) {
-            if (parent != null && parent.isArchived()) {
-                log.info("Skipping archived repo: {}", parent.getFullName());
-            }
-            return;
-        }
+        if (GitHub.shouldNotProcessDockerfilesInRepo(pathToDockerfilesInParentRepo, parent)) return;
 
         log.info("Fixing Dockerfiles in {}...", forkedRepo.getFullName());
         String parentName = parent.getFullName();

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -18,6 +18,7 @@ import com.salesforce.dockerfileimageupdate.repository.GitHub;
 import com.salesforce.dockerfileimageupdate.subcommands.ExecutableWithNamespace;
 import com.salesforce.dockerfileimageupdate.utils.Constants;
 import com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil;
+import com.salesforce.dockerfileimageupdate.utils.ResultsProcessor;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.kohsuke.github.GHContent;
 import org.kohsuke.github.GHMyself;
@@ -81,13 +82,7 @@ public class All implements ExecutableWithNamespace {
             }
         }
 
-        if (!exceptions.isEmpty()) {
-            throw new IOException(String.format("There were %s errors with changing Dockerfiles.", exceptions.size()));
-        }
-
-        if (!skippedRepos.isEmpty()) {
-            log.info("List of repos skipped: {}", skippedRepos);
-        }
+        ResultsProcessor.processResults(skippedRepos, exceptions, log);
     }
 
     protected void loadDockerfileGithubUtil(DockerfileGitHubUtil _dockerfileGitHubUtil) {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Child.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Child.java
@@ -9,6 +9,7 @@
 package com.salesforce.dockerfileimageupdate.subcommands.impl;
 
 import com.salesforce.dockerfileimageupdate.SubCommand;
+import com.salesforce.dockerfileimageupdate.model.GitForkBranch;
 import com.salesforce.dockerfileimageupdate.subcommands.ExecutableWithNamespace;
 import com.salesforce.dockerfileimageupdate.utils.Constants;
 import com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil;
@@ -37,29 +38,18 @@ public class Child implements ExecutableWithNamespace {
         log.info("Retrieving repository and creating fork...");
         GHRepository repo = dockerfileGitHubUtil.getRepo(ns.get(Constants.GIT_REPO));
         GHRepository fork = dockerfileGitHubUtil.getOrCreateFork(repo);
-        // TODO: Need to close PR
         if (fork == null) {
             log.info("Unable to fork {}. Please make sure that the repo is forkable.",
                     repo.getFullName());
             return;
         }
 
-        if (branch == null) {
-            branch = repo.getDefaultBranch();
-        }
-        log.info("Modifying on Github...");
-        dockerfileGitHubUtil.modifyAllOnGithub(fork, branch, img, forceTag);
-        dockerfileGitHubUtil.createPullReq(repo, branch, fork, ns.get(Constants.GIT_PR_TITLE));
+        GitForkBranch gitForkBranch = new GitForkBranch(img, forceTag, branch);
 
-        /* TODO: A potential problem that requires a design decision:
-         * 1. Leave forks in authenticated repository.
-         *    Pro: If the pull request has not been merged, it won't create a new pull request.
-         *    Con: Makes a lot of fork repositories on personal repository.
-         * 2. Delete forks in authenticated repository.
-         *    Pro: No extra repositories on personal repository; authenticated repository stays clean.
-         *    Con: If the pull request not merged yet, it will create a new pull request, making it harder for users
-         *         to read.
-         */
-//        fork.delete();
+        dockerfileGitHubUtil.createOrUpdateForkBranchToParentDefault(repo, fork, gitForkBranch);
+
+        log.info("Modifying on Github...");
+        dockerfileGitHubUtil.modifyAllOnGithub(fork, gitForkBranch.getBranchName(), img, forceTag);
+        dockerfileGitHubUtil.createPullReq(repo, gitForkBranch.getBranchName(), fork, ns.get(Constants.GIT_PR_TITLE));
     }
 }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Child.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Child.java
@@ -36,7 +36,8 @@ public class Child implements ExecutableWithNamespace {
 
         log.info("Retrieving repository and creating fork...");
         GHRepository repo = dockerfileGitHubUtil.getRepo(ns.get(Constants.GIT_REPO));
-        GHRepository fork = dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(repo);
+        GHRepository fork = dockerfileGitHubUtil.getOrCreateFork(repo);
+        // TODO: Need to close PR
         if (fork == null) {
             log.info("Unable to fork {}. Please make sure that the repo is forkable.",
                     repo.getFullName());

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Child.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Child.java
@@ -32,7 +32,7 @@ public class Child implements ExecutableWithNamespace {
         String forceTag = ns.get(Constants.FORCE_TAG);
 
         /* Updates store if a store is specified. */
-        dockerfileGitHubUtil.updateStore(ns.get(Constants.STORE), img, forceTag);
+        dockerfileGitHubUtil.getGitHubJsonStore(ns.get(Constants.STORE)).updateStore(img, forceTag);
 
         log.info("Retrieving repository and creating fork...");
         GHRepository repo = dockerfileGitHubUtil.getRepo(ns.get(Constants.GIT_REPO));

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Child.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Child.java
@@ -36,7 +36,7 @@ public class Child implements ExecutableWithNamespace {
 
         log.info("Retrieving repository and creating fork...");
         GHRepository repo = dockerfileGitHubUtil.getRepo(ns.get(Constants.GIT_REPO));
-        GHRepository fork = dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(repo);
+        GHRepository fork = dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(repo);
         if (fork == null) {
             log.info("Unable to fork {}. Please make sure that the repo is forkable.",
                     repo.getFullName());

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
@@ -16,6 +16,7 @@ import com.salesforce.dockerfileimageupdate.model.GitHubContentToProcess;
 import com.salesforce.dockerfileimageupdate.subcommands.ExecutableWithNamespace;
 import com.salesforce.dockerfileimageupdate.utils.Constants;
 import com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil;
+import com.salesforce.dockerfileimageupdate.utils.ResultsProcessor;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.kohsuke.github.GHContent;
 import org.kohsuke.github.GHPullRequest;
@@ -71,13 +72,8 @@ public class Parent implements ExecutableWithNamespace {
                 log.warn("Didn't find fork for {} so not changing Dockerfiles", currUserRepo);
             }
         }
-        if (!exceptions.isEmpty()) {
-            throw new IOException(String.format("There were %s errors with changing Dockerfiles.", exceptions.size()));
-        }
 
-        if (!skippedRepos.isEmpty()) {
-            log.info("List of repos skipped: {}", skippedRepos);
-        }
+        ResultsProcessor.processResults(skippedRepos, exceptions, log);
     }
 
     protected void loadDockerfileGithubUtil(DockerfileGitHubUtil _dockerfileGitHubUtil) {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
@@ -19,7 +19,6 @@ import com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil;
 import com.salesforce.dockerfileimageupdate.utils.ResultsProcessor;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.kohsuke.github.GHContent;
-import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.PagedSearchIterable;
 import org.slf4j.Logger;
@@ -125,19 +124,4 @@ public class Parent implements ExecutableWithNamespace {
             // TODO: Run through PRs in fork to see if they have head branches that match the prefix and close those?
         }
     }
-    private Optional<GHPullRequest> commentAndCloseExistingPullRequestsForBranch(GHRepository parentRepo, GitForkBranch gitForkBranch) {
-        Optional<GHPullRequest> specifiedBranchPullRequest = dockerfileGitHubUtil.getPullRequestForImageBranch(parentRepo, gitForkBranch);
-        //            GHPullRequest pullRequest = specifiedBranchPullRequest.get();
-        //            try {
-        //                pullRequest.comment(String.format("Closing PR due to PR update for image %s and tag %s",
-        //                        gitForkBranch.getImageName(), gitForkBranch.getImageTag()));
-        //                pullRequest.close();
-        //                log.info("Found and closed PR {}", pullRequest.getUrl());
-        //            } catch (IOException ioException) {
-        //                log.error("Error trying to comment/close PR for {}: {}", pullRequest.getUrl(), ioException.getMessage());
-        //            }
-        specifiedBranchPullRequest.ifPresent(ghPullRequest -> log.info("yeah... going to do the things on {}", ghPullRequest.getHtmlUrl()));
-        return specifiedBranchPullRequest;
-    }
-
 }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -331,4 +331,30 @@ public class DockerfileGitHubUtil {
         String myselfLogin = myself.getLogin();
         return repoOwner.equals(myselfLogin);
     }
+
+    /**
+     * Get GHContents for a provided image in the provided GitHub org.
+     *
+     * @param org GitHub organization
+     * @param img image to find
+     */
+    public Optional<PagedSearchIterable<GHContent>> getGHContents(String org, String img)
+            throws IOException, InterruptedException {
+        PagedSearchIterable<GHContent> contentsWithImage = null;
+        for (int i = 0; i < 5; i++) {
+            contentsWithImage = findFilesWithImage(img, org);
+            if (contentsWithImage.getTotalCount() > 0) {
+                break;
+            } else {
+                Thread.sleep(1000);
+            }
+        }
+
+        int numOfContentsFound = contentsWithImage.getTotalCount();
+        if (numOfContentsFound <= 0) {
+            log.info("Could not find any repositories with given image: {}", img);
+            return Optional.empty();
+        }
+        return Optional.of(contentsWithImage);
+    }
 }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -41,14 +41,18 @@ public class DockerfileGitHubUtil {
      *
      * @param parent the proposed/current fork parent
      * @return existing fork or new fork
-     * @throws IOException if we've encountered forking issues
      */
-    public GHRepository getOrCreateFork(GHRepository parent) throws IOException {
+    public GHRepository getOrCreateFork(GHRepository parent) {
         for (GHRepository fork : parent.listForks()) {
-            if (thisUserIsOwner(fork)) {
-                log.info("Fork exists, retrieving full info: {}", fork);
-                // NOTE: listForks() appears to miss information like parent data and GHContent parent doesn't have isArchived()
-                return fork;
+            try {
+                if (thisUserIsOwner(fork)) {
+                    log.info("Fork exists, retrieving full info: {}", fork);
+                    // NOTE: listForks() appears to miss information like parent data and GHContent parent doesn't have isArchived()
+                    return fork;
+                }
+            } catch (IOException ioException) {
+                log.error("Could not determine user to see if we can fork. Skipping.", ioException);
+                return null;
             }
         }
         log.info("Forking repo: {}", parent);

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -32,7 +32,7 @@ public class DockerfileGitHubUtil {
 
     protected GitHubUtil getGitHubUtil() { return gitHubUtil; }
 
-    public GHRepository closeOutdatedPullRequestAndFork(GHRepository parent) throws IOException {
+    public GHRepository getForkAndEnsureTargetBranchExistsFromDesiredBranch(GHRepository parent) throws IOException {
 
         for (GHRepository fork : parent.listForks()) {
             String forkOwner = fork.getOwnerName();

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Created by minho.park on 7/22/16.
@@ -109,7 +110,7 @@ public class DockerfileGitHubUtil {
                 break;
             } catch (FileNotFoundException e1) {
                 log.warn("Content in repository not created yet. Retrying connection to fork...");
-                Thread.sleep(1000);
+                Thread.sleep(TimeUnit.SECONDS.toMillis(1));
             }
         }
         for (GHContent con : tree) {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -289,7 +289,7 @@ public class DockerfileGitHubUtil {
             if (contentsWithImage.getTotalCount() > 0) {
                 break;
             } else {
-                Thread.sleep(1000);
+                Thread.sleep(TimeUnit.SECONDS.toMillis(1));
             }
         }
 

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -69,7 +69,8 @@ public class DockerfileGitHubUtil {
 
     public PagedSearchIterable<GHContent> findFilesWithImage(String query, String org) throws IOException {
         GHContentSearchBuilder search = gitHubUtil.startSearch();
-        search.language("Dockerfile");
+        // Filename search appears to yield better / more results than language:Dockerfile
+        search.filename("Dockerfile");
         if (org != null) {
             search.user(org);
         }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java
@@ -130,7 +130,7 @@ public class GitHubUtil {
                 break;
             } catch (IOException e1) {
                 log.warn("Repository not created yet. Retrying connection to repository...");
-                Thread.sleep(1000);
+                Thread.sleep(TimeUnit.SECONDS.toMillis(1));
             }
         }
         return repo;
@@ -147,7 +147,7 @@ public class GitHubUtil {
                 break;
             } catch (IOException e1) {
                 log.warn("Content in repository not created yet. Retrying connection to fork...");
-                Thread.sleep(1000);
+                Thread.sleep(TimeUnit.SECONDS.toMillis(1));
             }
         }
         return content;

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java
@@ -17,7 +17,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -72,12 +75,18 @@ public class GitHubUtil {
         return null;
     }
 
+    /**
+     * Attempt to delete the GitHub repo if there are no pull requests associated with it
+     * @param repo the repo to delete
+     */
     public void safeDeleteRepo(GHRepository repo) throws IOException {
-        try {
-            repo.delete();
-        } catch (IOException e) {
-            throw new IOException("Please verify that the GitHub token " +
-                    "provided has access to deleting repositories.");
+        if (!repo.queryPullRequests().state(GHIssueState.OPEN).list().iterator().hasNext()) {
+            try {
+                repo.delete();
+            } catch (IOException e) {
+                throw new IOException("Please verify that the GitHub token " +
+                        "provided has access to deleting repositories.");
+            }
         }
     }
 
@@ -86,15 +95,15 @@ public class GitHubUtil {
         log.info("Creating Pull Request on {} from {}...", origRepo.getFullName(), forkRepo.getFullName());
         //TODO: if no commits, pull request will fail, but this doesn't handle that.
         try {
-            origRepo.createPullRequest(title, forkRepo.getOwnerName() + ":" + branch,
+            GHPullRequest pullRequest = origRepo.createPullRequest(title, forkRepo.getOwnerName() + ":" + branch,
                     origRepo.getDefaultBranch(), body);
 //            origRepo.createPullRequest("Update base image in Dockerfile", forkRepo.getOwnerName() + ":" + branch,
 //                    origRepo.getDefaultBranch(), "Automatic Dockerfile Image Updater. Please merge.");
-            log.info("A pull request has been created. Please check on Github.");
+            log.info("A pull request has been created at {}. Please check on Github.", pullRequest.getUrl());
             return 0;
         } catch (IOException e) {
             log.warn("Handling error with pull request creation...");
-            JsonElement root = new JsonParser().parse(e.getMessage());
+            JsonElement root = JsonParser.parseString(e.getMessage());
             JsonArray errorJson = root.getAsJsonObject().get("errors").getAsJsonArray();
             String error = errorJson.get(0).getAsJsonObject().get("message").getAsString();
             log.info("error: {}", error);

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java
@@ -99,10 +99,10 @@ public class GitHubUtil {
                     origRepo.getDefaultBranch(), body);
 //            origRepo.createPullRequest("Update base image in Dockerfile", forkRepo.getOwnerName() + ":" + branch,
 //                    origRepo.getDefaultBranch(), "Automatic Dockerfile Image Updater. Please merge.");
-            log.info("A pull request has been created at {}. Please check on Github.", pullRequest.getUrl());
+            log.info("A pull request has been created at {}", pullRequest.getHtmlUrl());
             return 0;
         } catch (IOException e) {
-            log.warn("Handling error with pull request creation...");
+            log.warn("Handling error with pull request creation... {}", e.getMessage());
             JsonElement root = JsonParser.parseString(e.getMessage());
             JsonArray errorJson = root.getAsJsonObject().get("errors").getAsJsonArray();
             String error = errorJson.get(0).getAsJsonObject().get("message").getAsString();
@@ -114,6 +114,7 @@ public class GitHubUtil {
                 log.warn("NOTE: {} Pull request was not created.", error);
                 return 1;
             } else {
+                // TODO: THIS WILL LOOP FOREVVEEEEEERRRR
                 log.warn("An error occurred in pull request: {} Trying again...", error);
                 Thread.sleep(3000);
                 return -1;

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/ResultsProcessor.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/ResultsProcessor.java
@@ -1,0 +1,32 @@
+package com.salesforce.dockerfileimageupdate.utils;
+
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Processes results of a rur
+ */
+public class ResultsProcessor {
+
+    public static final String REPOS_SKIPPED_MESSAGE = "List of repos skipped: {}";
+
+    /**
+     * Process the results of a run and output for the user
+     *
+     * @param skippedRepos repos that were skipped during processing
+     * @param exceptions exceptions that occurred during processing
+     * @param logger logger of the caller
+     * @throws IOException throws if there are exceptions
+     */
+    public static void processResults(List<String> skippedRepos, List<IOException> exceptions, Logger logger) throws IOException {
+        if (!skippedRepos.isEmpty()) {
+            logger.info(REPOS_SKIPPED_MESSAGE, skippedRepos);
+        }
+
+        if (!exceptions.isEmpty()) {
+            throw new IOException(String.format("There were %s errors with changing Dockerfiles.", exceptions.size()));
+        }
+    }
+}

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/FromInstructionTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/FromInstructionTest.java
@@ -9,7 +9,7 @@ import static org.testng.Assert.assertEquals;
 public class FromInstructionTest {
 
     @DataProvider
-    public Object[][] inputFormInstructionData() {
+    public Object[][] inputFromInstructionData() {
         return new Object[][]{
                 {"FROM dockerimage:3 # some comment",               "FROM dockerimage:3 # some comment"},
                 {"FROM dockerimage:3 AS test",                      "FROM dockerimage:3 AS test"},
@@ -22,7 +22,7 @@ public class FromInstructionTest {
         };
     }
 
-    @Test(dataProvider = "inputFormInstructionData")
+    @Test(dataProvider = "inputFromInstructionData")
     public void testStringResult(String fromInstruction, String expectedResult) {
         assertEquals(new FromInstruction(fromInstruction).toString(), expectedResult);
     }

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/GitForkBranchTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/GitForkBranchTest.java
@@ -1,0 +1,71 @@
+package com.salesforce.dockerfileimageupdate.model;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class GitForkBranchTest {
+    @DataProvider
+    public Object[][] imageNameAndExpectedBranch() {
+        return new Object[][]{
+                {"docker.io/some/container",     "",     "docker.io/some/container"},
+                {"127.0.0.1:443/some/container", "",     "127.0.0.1-443/some/container"},
+                {"docker.io/some/container",     "123",  "docker.io/some/container-123"},
+                {"docker.io/some/container",     "   ",  "docker.io/some/container"},
+                {"docker.io/some/container",     null,   "docker.io/some/container"},
+        };
+    }
+
+    @Test(dataProvider = "imageNameAndExpectedBranch")
+    public void testGetBranchNameForImageTagCombos(String imageName, String imageTag, String expectedResult) {
+        assertEquals(new GitForkBranch(imageName, imageTag, "").getBranchName(), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] imageNameAndSpecifiedBranches() {
+        return new Object[][]{
+                {"docker.io/some/container",     "",     "blah", "blah"},
+                {"127.0.0.1:443/some/container", "",     "test", "test"},
+                {"docker.io/some/container",     "123",  "",     "docker.io/some/container-123"},
+                {"docker.io/some/container",     "   ",  null,   "docker.io/some/container"},
+                {"docker.io/some/container",     null,   "",     "docker.io/some/container"},
+        };
+    }
+
+    @Test(dataProvider = "imageNameAndSpecifiedBranches")
+    public void testGetBranchNameForImageSpecifiedBranchCombos(String imageName, String imageTag, String specifiedBranch, String expectedResult) {
+        assertEquals(new GitForkBranch(imageName, imageTag, specifiedBranch).getBranchName(), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] sameBranchOrImageNamePrefix() {
+        return new Object[][]{
+                {"docker.io/some/container",     "",     "blah", "blah",                             true},
+                {"127.0.0.1:443/some/container", "",     "test", "test",                             true},
+                {"docker.io/some/container",     "123",  "",     "docker.io/some/container-123",     true},
+                {"127.0.0.1:443/some/container", "123",     "",  "127.0.0.1-443/some/container-987", true},
+                {"docker.io/some/container",     "345",  "",     "docker.io/some/container-123",     true},
+                {"docker.io/some/container",     "345",  "",     "docker.io/some/container-432",     true},
+                {"docker.io/some/container",     "345",  "",     "docker.io/some/container",         true},
+                {"docker.io/some/container  ",   "345",  "",     "docker.io/some/container",         true},
+                {"  docker.io/some/container",   "345",  "",     "docker.io/some/container",         true},
+                {"  docker.io/some/container",   "345",  "",     "  docker.io/some/container",       true},
+                {"  docker.io/some/container",   "345",  "",     "  docker.io/some/container  ",     true},
+                {"  docker.io/some/container",   "345",  "",     "docker.io/some/container  ",       true},
+                {"docker.io/some/container",     "   ",  null,   "docker.io/some/container",         true},
+                {"docker.io/some/container",     null,   "",     "docker.io/some/container",         true},
+                {"docker.io/some/container",     "12",   "",     null,                               false},
+        };
+    }
+
+    @Test(dataProvider = "sameBranchOrImageNamePrefix")
+    public void testIsSameBranchOrHasImageNamePrefix(String imageName, String imageTag, String specifiedBranch, String inputBranch, boolean expectedResult) {
+        assertEquals(new GitForkBranch(imageName, imageTag, specifiedBranch).isSameBranchOrHasImageNamePrefix(inputBranch), expectedResult);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testIsSameBranchOrHasImageNamePrefix() {
+        new GitForkBranch("", "1", "");
+    }
+}

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/GitForkBranchTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/GitForkBranchTest.java
@@ -3,7 +3,7 @@ package com.salesforce.dockerfileimageupdate.model;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 public class GitForkBranchTest {
     @DataProvider

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/process/GitHubPullRequestSenderTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/process/GitHubPullRequestSenderTest.java
@@ -1,0 +1,206 @@
+package com.salesforce.dockerfileimageupdate.process;
+
+import com.google.common.collect.Multimap;
+import com.salesforce.dockerfileimageupdate.model.GitHubContentToProcess;
+import com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil;
+import org.kohsuke.github.GHContent;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.PagedIterator;
+import org.kohsuke.github.PagedSearchIterable;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class GitHubPullRequestSenderTest {
+
+    @Test
+    public void testForkRepositoriesFound() throws Exception {
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+
+        GHRepository contentRepo1 = mock(GHRepository.class);
+        when(contentRepo1.getFullName()).thenReturn("1");
+        GHRepository contentRepo2 = mock(GHRepository.class);
+        when(contentRepo2.getFullName()).thenReturn("2");
+        GHRepository contentRepo3 = mock(GHRepository.class);
+        when(contentRepo3.getFullName()).thenReturn("3");
+
+
+        GHContent content1 = mock(GHContent.class);
+        when(content1.getOwner()).thenReturn(contentRepo1);
+        GHContent content2 = mock(GHContent.class);
+        when(content2.getOwner()).thenReturn(contentRepo2);
+        GHContent content3 = mock(GHContent.class);
+        when(content3.getOwner()).thenReturn(contentRepo3);
+
+        PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
+
+        PagedIterator<GHContent> contentsWithImageIterator = mock(PagedIterator.class);
+        when(contentsWithImageIterator.hasNext()).thenReturn(true, true, true, false);
+        when(contentsWithImageIterator.next()).thenReturn(content1, content2, content3, null);
+        when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
+
+        when(dockerfileGitHubUtil.getOrCreateFork(Mockito.any())).thenReturn(new GHRepository());
+        when(dockerfileGitHubUtil.getRepo(any())).thenReturn(mock(GHRepository.class));
+
+        GitHubPullRequestSender pullRequestSender = new GitHubPullRequestSender(dockerfileGitHubUtil);
+        Multimap<String, GitHubContentToProcess> repoMap =  pullRequestSender.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
+
+        verify(dockerfileGitHubUtil, times(3)).getOrCreateFork(any());
+        assertEquals(repoMap.size(), 3);
+    }
+
+    @Test
+    public void forkRepositoriesFoundAndGetPathToDockerfiles_unableToforkRepo() throws Exception {
+        /**
+         * Suppose we have multiple dockerfiles that need to updated in a repo and we fail to fork such repo,
+         * we should not add those repos to pathToDockerfilesInParentRepo.
+         *
+         * Note: Sometimes GitHub search API returns the same result twice. This test covers such cases as well.
+         */
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+
+        GHRepository contentRepo1 = mock(GHRepository.class);
+        when(contentRepo1.getFullName()).thenReturn("1");
+
+        GHRepository duplicateContentRepo1 = mock(GHRepository.class);
+        // Say we have multiple dockerfiles to be updated in repo "1"
+        // Or sometimes GitHub search API returns same result twice.
+        when(duplicateContentRepo1.getFullName()).thenReturn("1");
+
+        GHRepository contentRepo2 = mock(GHRepository.class);
+        when(contentRepo2.getFullName()).thenReturn("2");
+
+        GHContent content1 = mock(GHContent.class);
+        when(content1.getOwner()).thenReturn(contentRepo1);
+        when(content1.getPath()).thenReturn("1"); // path to 1st dockerfile in repo "1"
+
+        GHContent content2 = mock(GHContent.class);
+        when(content2.getOwner()).thenReturn(duplicateContentRepo1);
+        when(content2.getPath()).thenReturn("2"); // path to 2st dockerfile in repo "1"
+
+        GHContent content3 = mock(GHContent.class);
+        when(content3.getOwner()).thenReturn(contentRepo2);
+        when(content3.getPath()).thenReturn("3");
+
+        PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
+
+        PagedIterator<GHContent> contentsWithImageIterator = mock(PagedIterator.class);
+        when(contentsWithImageIterator.hasNext()).thenReturn(true, true, true, false);
+        when(contentsWithImageIterator.next()).thenReturn(content1, content2, content3, null);
+        when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
+        when(dockerfileGitHubUtil.getOrCreateFork(contentRepo1)).thenReturn(null); // repo1 is unforkable
+        when(dockerfileGitHubUtil.getOrCreateFork(duplicateContentRepo1)).thenReturn(null); // repo1 is unforkable
+        when(dockerfileGitHubUtil.getOrCreateFork(contentRepo2)).thenReturn(mock(GHRepository.class));
+        when(dockerfileGitHubUtil.getRepo(contentRepo1.getFullName())).thenReturn(contentRepo1);
+        when(dockerfileGitHubUtil.getRepo(duplicateContentRepo1.getFullName())).thenReturn(duplicateContentRepo1);
+        when(dockerfileGitHubUtil.getRepo(contentRepo2.getFullName())).thenReturn(contentRepo2);
+
+        GitHubPullRequestSender pullRequestSender = new GitHubPullRequestSender(dockerfileGitHubUtil);
+        Multimap<String, GitHubContentToProcess> repoMap =  pullRequestSender.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
+
+        // Since repo "1" is unforkable, we will only try to update repo "2"
+        verify(dockerfileGitHubUtil, times(3)).getOrCreateFork(any());
+        assertEquals(repoMap.size(), 1);
+    }
+
+    @Test
+    public void testForkRepositoriesFound_forkRepoIsSkipped() throws Exception {
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+
+        GHRepository contentRepo1 = mock(GHRepository.class);
+        when(contentRepo1.getFullName()).thenReturn("1");
+
+        GHContent content1 = mock(GHContent.class);
+        when(content1.getOwner()).thenReturn(contentRepo1);
+        when(contentRepo1.isFork()).thenReturn(true);
+
+        PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
+
+        PagedIterator<GHContent> contentsWithImageIterator = mock(PagedIterator.class);
+        when(contentsWithImageIterator.hasNext()).thenReturn(true, false);
+        when(contentsWithImageIterator.next()).thenReturn(content1, null);
+        when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
+
+        when(dockerfileGitHubUtil.getRepo(any())).thenReturn(contentRepo1);
+
+        GitHubPullRequestSender pullRequestSender = new GitHubPullRequestSender(dockerfileGitHubUtil);
+        Multimap<String, GitHubContentToProcess> repoMap = pullRequestSender.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
+
+        verify(dockerfileGitHubUtil, never()).getOrCreateFork(any());
+        assertEquals(repoMap.size(), 0);
+    }
+
+    @Test
+    public void testPullRequestToAForkIsUnSupported() throws Exception {
+
+        GHRepository parentRepo = mock(GHRepository.class);
+        // When the repo is a fork then skip it.
+        when(parentRepo.isFork()).thenReturn(true);
+        GHContent content = mock(GHContent.class);
+        when(content.getOwner()).thenReturn(parentRepo);
+
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
+        PagedIterator<GHContent> contentsWithImageIterator = mock(PagedIterator.class);
+        when(contentsWithImageIterator.hasNext()).thenReturn(true, false);
+        when(contentsWithImageIterator.next()).thenReturn(content, null);
+        when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
+
+        when(dockerfileGitHubUtil.getRepo(any())).thenReturn(parentRepo);
+
+        GitHubPullRequestSender pullRequestSender = new GitHubPullRequestSender(dockerfileGitHubUtil);
+        Multimap<String, GitHubContentToProcess> pathToDockerfiles = pullRequestSender.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
+        assertTrue(pathToDockerfiles.isEmpty());
+        Mockito.verify(dockerfileGitHubUtil, times(0)).getOrCreateFork(any());
+    }
+// TODO: COVER THIS SCENARIO
+//    @Test
+//    public void checkPullRequestNotMadeForArchived() throws Exception {
+//        final String repoName = "mock repo";
+//        Map<String, Object> nsMap = ImmutableMap.of(Constants.IMG,
+//                "image", Constants.TAG,
+//                "tag", Constants.STORE,
+//                "store");
+//        Namespace ns = new Namespace(nsMap);
+//
+//        GHRepository parentRepo = mock(GHRepository.class);
+//        GHRepository forkRepo = mock(GHRepository.class);
+//        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+//        GHContent content = mock(GHContent.class);
+//        GHMyself myself = mock(GHMyself.class);
+//
+//        when(parentRepo.isArchived()).thenReturn(true);
+//
+//        when(parentRepo.getFullName()).thenReturn(repoName);
+//        when(forkRepo.getFullName()).thenReturn(repoName);
+//        when(content.getOwner()).thenReturn(parentRepo);
+//        when(dockerfileGitHubUtil.getRepo(eq(repoName))).thenReturn(forkRepo);
+//        when(forkRepo.isFork()).thenReturn(true);
+//        when(forkRepo.getParent()).thenReturn(parentRepo);
+//        when(dockerfileGitHubUtil.getMyself()).thenReturn(myself);
+//        when(dockerfileGitHubUtil.getPullRequestForImageBranch(any(), any())).thenReturn(Optional.empty());
+//
+//        Multimap<String, ForkWithContentPath> pathToDockerfilesInParentRepo = HashMultimap.create();
+//        pathToDockerfilesInParentRepo.put(repoName, null);
+//
+//        Parent parent = new Parent();
+//        parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
+//        PagedSearchIterable<GHContent> results = mock(PagedSearchIterable.class);
+//        PagedIterator<GHContent> iterator = mock(PagedIterator.class);
+//        when(results.iterator()).thenReturn(iterator);
+//        when(iterator.hasNext()).thenReturn(true, false);
+//        when(iterator.next()).thenReturn(content);
+////        Multimap<String, ForkWithContentPath> forks = parent.forkRepositoriesFoundAndGetPathToDockerfiles(results);
+//        parent.changeDockerfiles(ns, pathToDockerfilesInParentRepo, forkRepo, Collections.emptyList());
+//
+//        Mockito.verify(dockerfileGitHubUtil, Mockito.never())
+//                .createPullReq(Mockito.any(), anyString(), Mockito.any(), anyString());
+//        //Make sure we at least call the isArchived.
+//        Mockito.verify(parentRepo, Mockito.times(1)).isArchived();
+////        assertTrue(forks.isEmpty());
+//    }
+}

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/repository/GitHubTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/repository/GitHubTest.java
@@ -1,0 +1,52 @@
+package com.salesforce.dockerfileimageupdate.repository;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import org.kohsuke.github.GHRepository;
+import org.mockito.Mock;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class GitHubTest {
+    String repoName = "some-repo-name";
+
+    @Mock
+    GHRepository gitHubRepository;
+
+
+    @Test
+    public void testShouldNotProcessBecauseNullParent() {
+        assertTrue(GitHub.shouldNotProcessDockerfilesInRepo(null, null));
+    }
+
+    @Test
+    public void testShouldNotProcessBecauseDidNotFindDockerfiles() {
+        gitHubRepository = mock(GHRepository.class);
+        when(gitHubRepository.getFullName()).thenReturn(repoName);
+        Multimap<String, String> multimap = HashMultimap.create();
+        assertTrue(GitHub.shouldNotProcessDockerfilesInRepo(multimap, gitHubRepository));
+    }
+
+    @Test
+    public void testShouldNotProcessBecauseIsArchived() {
+        gitHubRepository = mock(GHRepository.class);
+        when(gitHubRepository.getFullName()).thenReturn(repoName);
+        when(gitHubRepository.isArchived()).thenReturn(true);
+        Multimap<String, String> multimap = HashMultimap.create();
+        multimap.put(repoName, null);
+        assertTrue(GitHub.shouldNotProcessDockerfilesInRepo(multimap, gitHubRepository));
+    }
+
+    @Test
+    public void testShouldProcess() {
+        gitHubRepository = mock(GHRepository.class);
+        when(gitHubRepository.getFullName()).thenReturn(repoName);
+        Multimap<String, String> multimap = HashMultimap.create();
+        multimap.put(repoName, null);
+        assertFalse(GitHub.shouldNotProcessDockerfilesInRepo(multimap, gitHubRepository));
+    }
+}

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/storage/GitHubJsonStoreTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/storage/GitHubJsonStoreTest.java
@@ -1,0 +1,91 @@
+package com.salesforce.dockerfileimageupdate.storage;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.salesforce.dockerfileimageupdate.utils.GitHubUtil;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+
+public class GitHubJsonStoreTest {
+    @DataProvider
+    public Object[][] inputStores() throws Exception {
+        return new Object[][] {
+                {"{\n  \"images\": {\n" +
+                        "    \"test\": \"testingtest\",\n" +
+                        "    \"asdfjkl\": \"asdfjkl\",\n" +
+                        "    \"7fce8488-31f4-4137-ad68-c19c3b33eebb\": \"manualtest\"\n" +
+                        "  }\n" +
+                        "}",
+                        "test", "newtag",
+                        "{\n  \"images\": {\n" +
+                                "    \"test\": \"newtag\",\n" +
+                                "    \"asdfjkl\": \"asdfjkl\",\n" +
+                                "    \"7fce8488-31f4-4137-ad68-c19c3b33eebb\": \"manualtest\"\n" +
+                                "  }\n" +
+                                "}"},
+                {"{\n  \"images\": {\n" +
+                        "    \"test\": \"testingtest\",\n" +
+                        "    \"asdfjkl\": \"asdfjkl\",\n" +
+                        "    \"7fce8488-31f4-4137-ad68-c19c3b33eebb\": \"manualtest\"\n" +
+                        "  }\n" +
+                        "}",
+                        "test", "test",
+                        "{\n  \"images\": {\n" +
+                                "    \"test\": \"test\",\n" +
+                                "    \"asdfjkl\": \"asdfjkl\",\n" +
+                                "    \"7fce8488-31f4-4137-ad68-c19c3b33eebb\": \"manualtest\"\n" +
+                                "  }\n" +
+                                "}"},
+                {"{\n  \"images\": {\n" +
+                        "    \"test\": \"testingtest\",\n" +
+                        "    \"asdfjkl\": \"asdfjkl\",\n" +
+                        "    \"7fce8488-31f4-4137-ad68-c19c3b33eebb\": \"manualtest\"\n" +
+                        "  }\n" +
+                        "}",
+                        "newImage", "newtag2",
+                        "{\n  \"images\": {\n" +
+                                "    \"test\": \"testingtest\",\n" +
+                                "    \"asdfjkl\": \"asdfjkl\",\n" +
+                                "    \"7fce8488-31f4-4137-ad68-c19c3b33eebb\": \"manualtest\",\n" +
+                                "    \"newImage\": \"newtag2\"\n" +
+                                "  }\n" +
+                                "}"},
+                {"{}", "image", "tag",
+                        "{\n  \"images\": {\n" +
+                                "    \"image\": \"tag\"\n" +
+                                "  }\n" +
+                                "}"},
+                {"{}", "test", "test",
+                        "{\n  \"images\": {\n" +
+                                "    \"test\": \"test\"\n" +
+                                "  }\n" +
+                                "}"},
+                {"", "image", "tag",
+                        "{\n  \"images\": {\n" +
+                                "    \"image\": \"tag\"\n" +
+                                "  }\n" +
+                                "}"},
+                {"{\n  \"images\": {\n" +
+                        "  }\n" +
+                        "}",
+                        "image", "tag",
+                        "{\n  \"images\": {\n" +
+                                "    \"image\": \"tag\"\n" +
+                                "  }\n" +
+                                "}"}
+
+        };
+    }
+
+    @Test(dataProvider = "inputStores")
+    public void testGetAndModifyJsonString(String storeContent, String image, String tag, String expectedOutput) throws Exception {
+        GitHubUtil gitHubUtil = mock(GitHubUtil.class);
+        JsonElement json = JsonParser.parseString(storeContent);
+
+        String output = new GitHubJsonStore(gitHubUtil, "test").getAndModifyJsonString(json, image, tag);
+        assertEquals(output, expectedOutput);
+    }
+}

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/AllTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/AllTest.java
@@ -60,7 +60,7 @@ public class AllTest {
         all.loadDockerfileGithubUtil(dockerfileGitHubUtil);
         all.forkRepositoriesFound(ArrayListMultimap.create(), ArrayListMultimap.create(), contentsWithImage, "image");
 
-        Mockito.verify(dockerfileGitHubUtil, times(3)).closeOutdatedPullRequestAndFork(any());
+        Mockito.verify(dockerfileGitHubUtil, times(3)).getForkAndEnsureTargetBranchExistsFromDesiredBranch(any());
     }
 
     @Test
@@ -99,9 +99,9 @@ public class AllTest {
         when(contentsWithImageIterator.hasNext()).thenReturn(true, true, true, false);
         when(contentsWithImageIterator.next()).thenReturn(content1, content2, content3, null);
         when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
-        when(dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(contentRepo1)).thenReturn(null); // repo1 is unforkable
-        when(dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(contentRepo2)).thenReturn(null); // repo1 is unforkable
-        when(dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(contentRepo3)).thenReturn(new GHRepository());
+        when(dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(contentRepo1)).thenReturn(null); // repo1 is unforkable
+        when(dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(contentRepo2)).thenReturn(null); // repo1 is unforkable
+        when(dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(contentRepo3)).thenReturn(new GHRepository());
 
         All all = new All();
         all.loadDockerfileGithubUtil(dockerfileGitHubUtil);
@@ -112,7 +112,7 @@ public class AllTest {
         // Since repo "1" is unforkable, we only added repo "2" to pathToDockerfilesInParentRepo
         assertEquals(pathToDockerfilesInParentRepo.size(), 1);
         assertEquals(imagesFoundInParentRepo.size(), 1);
-        Mockito.verify(dockerfileGitHubUtil, times(3)).closeOutdatedPullRequestAndFork(any());
+        Mockito.verify(dockerfileGitHubUtil, times(3)).getForkAndEnsureTargetBranchExistsFromDesiredBranch(any());
     }
 
     @Test
@@ -394,7 +394,7 @@ public class AllTest {
         All all = new All();
         all.loadDockerfileGithubUtil(dockerfileGitHubUtil);
         all.forkRepositoriesFound(ArrayListMultimap.create(), ArrayListMultimap.create(), contentsWithImage, "image");
-        Mockito.verify(dockerfileGitHubUtil, times(0)).closeOutdatedPullRequestAndFork(any());
+        Mockito.verify(dockerfileGitHubUtil, times(0)).getForkAndEnsureTargetBranchExistsFromDesiredBranch(any());
     }
 
     @Test

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/AllTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/AllTest.java
@@ -60,7 +60,7 @@ public class AllTest {
         all.loadDockerfileGithubUtil(dockerfileGitHubUtil);
         all.forkRepositoriesFound(ArrayListMultimap.create(), ArrayListMultimap.create(), contentsWithImage, "image");
 
-        Mockito.verify(dockerfileGitHubUtil, times(3)).getForkAndEnsureTargetBranchExistsFromDesiredBranch(any());
+        Mockito.verify(dockerfileGitHubUtil, times(3)).getOrCreateFork(any());
     }
 
     @Test
@@ -99,9 +99,9 @@ public class AllTest {
         when(contentsWithImageIterator.hasNext()).thenReturn(true, true, true, false);
         when(contentsWithImageIterator.next()).thenReturn(content1, content2, content3, null);
         when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
-        when(dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(contentRepo1)).thenReturn(null); // repo1 is unforkable
-        when(dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(contentRepo2)).thenReturn(null); // repo1 is unforkable
-        when(dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(contentRepo3)).thenReturn(new GHRepository());
+        when(dockerfileGitHubUtil.getOrCreateFork(contentRepo1)).thenReturn(null); // repo1 is unforkable
+        when(dockerfileGitHubUtil.getOrCreateFork(contentRepo2)).thenReturn(null); // repo1 is unforkable
+        when(dockerfileGitHubUtil.getOrCreateFork(contentRepo3)).thenReturn(new GHRepository());
 
         All all = new All();
         all.loadDockerfileGithubUtil(dockerfileGitHubUtil);
@@ -112,7 +112,7 @@ public class AllTest {
         // Since repo "1" is unforkable, we only added repo "2" to pathToDockerfilesInParentRepo
         assertEquals(pathToDockerfilesInParentRepo.size(), 1);
         assertEquals(imagesFoundInParentRepo.size(), 1);
-        Mockito.verify(dockerfileGitHubUtil, times(3)).getForkAndEnsureTargetBranchExistsFromDesiredBranch(any());
+        Mockito.verify(dockerfileGitHubUtil, times(3)).getOrCreateFork(any());
     }
 
     @Test
@@ -394,7 +394,7 @@ public class AllTest {
         All all = new All();
         all.loadDockerfileGithubUtil(dockerfileGitHubUtil);
         all.forkRepositoriesFound(ArrayListMultimap.create(), ArrayListMultimap.create(), contentsWithImage, "image");
-        Mockito.verify(dockerfileGitHubUtil, times(0)).getForkAndEnsureTargetBranchExistsFromDesiredBranch(any());
+        Mockito.verify(dockerfileGitHubUtil, times(0)).getOrCreateFork(any());
     }
 
     @Test

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ChildTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ChildTest.java
@@ -52,7 +52,7 @@ public class ChildTest {
         Namespace ns = new Namespace(inputMap);
         DockerfileGitHubUtil dockerfileGitHubUtil = Mockito.mock(DockerfileGitHubUtil.class);
         Mockito.when(dockerfileGitHubUtil.getRepo(Mockito.any())).thenReturn(new GHRepository());
-        Mockito.when(dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(Mockito.any())).thenReturn(new GHRepository());
+        Mockito.when(dockerfileGitHubUtil.getOrCreateFork(Mockito.any())).thenReturn(new GHRepository());
         doNothing().when(dockerfileGitHubUtil).modifyAllOnGithub(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
         doNothing().when(dockerfileGitHubUtil).updateStore(anyString(), anyString(), anyString());
         doNothing().when(dockerfileGitHubUtil).createPullReq(Mockito.any(), anyString(), Mockito.any(), anyString());
@@ -74,7 +74,7 @@ public class ChildTest {
         Namespace ns = new Namespace(nsMap);
         DockerfileGitHubUtil dockerfileGitHubUtil = Mockito.mock(DockerfileGitHubUtil.class);
         Mockito.when(dockerfileGitHubUtil.getRepo(Mockito.any())).thenReturn(new GHRepository());
-        Mockito.when(dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(Mockito.any())).thenReturn(null);
+        Mockito.when(dockerfileGitHubUtil.getOrCreateFork(Mockito.any())).thenReturn(null);
         child.execute(ns, dockerfileGitHubUtil);
         Mockito.verify(dockerfileGitHubUtil, Mockito.never()).createPullReq(Mockito.any(), Mockito.any(), Mockito.any(),
                 Mockito.any());

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ChildTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ChildTest.java
@@ -9,6 +9,7 @@
 package com.salesforce.dockerfileimageupdate.subcommands.impl;
 
 import com.google.common.collect.ImmutableMap;
+import com.salesforce.dockerfileimageupdate.storage.GitHubJsonStore;
 import com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.kohsuke.github.GHRepository;
@@ -22,8 +23,7 @@ import java.util.Map;
 
 import static com.salesforce.dockerfileimageupdate.utils.Constants.*;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.*;
 
 /**
  * Created by minho.park on 7/19/16.
@@ -50,11 +50,12 @@ public class ChildTest {
     public void checkPullRequestMade(Map<String, Object> inputMap) throws Exception {
         Child child = new Child();
         Namespace ns = new Namespace(inputMap);
-        DockerfileGitHubUtil dockerfileGitHubUtil = Mockito.mock(DockerfileGitHubUtil.class);
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
         Mockito.when(dockerfileGitHubUtil.getRepo(Mockito.any())).thenReturn(new GHRepository());
         Mockito.when(dockerfileGitHubUtil.getOrCreateFork(Mockito.any())).thenReturn(new GHRepository());
         doNothing().when(dockerfileGitHubUtil).modifyAllOnGithub(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
-        doNothing().when(dockerfileGitHubUtil).updateStore(anyString(), anyString(), anyString());
+        GitHubJsonStore gitHubJsonStore = mock(GitHubJsonStore.class);
+        when(dockerfileGitHubUtil.getGitHubJsonStore(anyString())).thenReturn(gitHubJsonStore);
         doNothing().when(dockerfileGitHubUtil).createPullReq(Mockito.any(), anyString(), Mockito.any(), anyString());
 
         child.execute(ns, dockerfileGitHubUtil);
@@ -72,7 +73,9 @@ public class ChildTest {
                 FORCE_TAG, "test",
                 STORE, "test");
         Namespace ns = new Namespace(nsMap);
-        DockerfileGitHubUtil dockerfileGitHubUtil = Mockito.mock(DockerfileGitHubUtil.class);
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        GitHubJsonStore gitHubJsonStore = mock(GitHubJsonStore.class);
+        when(dockerfileGitHubUtil.getGitHubJsonStore(anyString())).thenReturn(gitHubJsonStore);
         Mockito.when(dockerfileGitHubUtil.getRepo(Mockito.any())).thenReturn(new GHRepository());
         Mockito.when(dockerfileGitHubUtil.getOrCreateFork(Mockito.any())).thenReturn(null);
         child.execute(ns, dockerfileGitHubUtil);

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ChildTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ChildTest.java
@@ -52,7 +52,7 @@ public class ChildTest {
         Namespace ns = new Namespace(inputMap);
         DockerfileGitHubUtil dockerfileGitHubUtil = Mockito.mock(DockerfileGitHubUtil.class);
         Mockito.when(dockerfileGitHubUtil.getRepo(Mockito.any())).thenReturn(new GHRepository());
-        Mockito.when(dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(Mockito.any())).thenReturn(new GHRepository());
+        Mockito.when(dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(Mockito.any())).thenReturn(new GHRepository());
         doNothing().when(dockerfileGitHubUtil).modifyAllOnGithub(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
         doNothing().when(dockerfileGitHubUtil).updateStore(anyString(), anyString(), anyString());
         doNothing().when(dockerfileGitHubUtil).createPullReq(Mockito.any(), anyString(), Mockito.any(), anyString());
@@ -74,7 +74,7 @@ public class ChildTest {
         Namespace ns = new Namespace(nsMap);
         DockerfileGitHubUtil dockerfileGitHubUtil = Mockito.mock(DockerfileGitHubUtil.class);
         Mockito.when(dockerfileGitHubUtil.getRepo(Mockito.any())).thenReturn(new GHRepository());
-        Mockito.when(dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(Mockito.any())).thenReturn(null);
+        Mockito.when(dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(Mockito.any())).thenReturn(null);
         child.execute(ns, dockerfileGitHubUtil);
         Mockito.verify(dockerfileGitHubUtil, Mockito.never()).createPullReq(Mockito.any(), Mockito.any(), Mockito.any(),
                 Mockito.any());

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ChildTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ChildTest.java
@@ -18,7 +18,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
 
 import static com.salesforce.dockerfileimageupdate.utils.Constants.*;
@@ -33,7 +32,6 @@ public class ChildTest {
     @DataProvider
     public Object[][] inputMap() {
         return new Object[][] {
-                {Collections.emptyMap()},
                 {ImmutableMap.of(
                         GIT_REPO, "test",
                         IMG, "test",

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ParentTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ParentTest.java
@@ -11,7 +11,7 @@ package com.salesforce.dockerfileimageupdate.subcommands.impl;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
-import com.salesforce.dockerfileimageupdate.subcommands.impl.Parent.ForkWithContentPath;
+import com.salesforce.dockerfileimageupdate.model.GitHubContentToProcess;
 import com.salesforce.dockerfileimageupdate.utils.Constants;
 import com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -105,7 +105,7 @@ public class ParentTest {
 
         Parent parent = new Parent();
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        Multimap<String, ForkWithContentPath> repoMap =  parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
+        Multimap<String, GitHubContentToProcess> repoMap =  parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
 
         verify(dockerfileGitHubUtil, times(3)).getOrCreateFork(any());
         assertEquals(repoMap.size(), 3);
@@ -159,7 +159,7 @@ public class ParentTest {
 
         Parent parent = new Parent();
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        Multimap<String, ForkWithContentPath> repoMap =  parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
+        Multimap<String, GitHubContentToProcess> repoMap =  parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
 
         // Since repo "1" is unforkable, we will only try to update repo "2"
         verify(dockerfileGitHubUtil, times(3)).getOrCreateFork(any());
@@ -188,7 +188,7 @@ public class ParentTest {
 
         Parent parent = new Parent();
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        Multimap<String, ForkWithContentPath> repoMap = parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
+        Multimap<String, GitHubContentToProcess> repoMap = parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
 
         verify(dockerfileGitHubUtil, never()).getOrCreateFork(any());
         assertEquals(repoMap.size(), 0);
@@ -207,11 +207,11 @@ public class ParentTest {
         when(parentRepo.getFullName()).thenReturn("repo2");
         when(forkedRepo.getParent()).thenReturn(parentRepo);
 
-        Multimap<String, ForkWithContentPath> pathToDockerfilesInParentRepo = HashMultimap.create();
-        pathToDockerfilesInParentRepo.put("repo1", new ForkWithContentPath(null, null, "df1"));
-        pathToDockerfilesInParentRepo.put("repo2", new ForkWithContentPath(null, null, "df2"));
-        pathToDockerfilesInParentRepo.put("repo3", new ForkWithContentPath(null, null, "df3"));
-        pathToDockerfilesInParentRepo.put("repo4", new ForkWithContentPath(null, null, "df4"));
+        Multimap<String, GitHubContentToProcess> pathToDockerfilesInParentRepo = HashMultimap.create();
+        pathToDockerfilesInParentRepo.put("repo1", new GitHubContentToProcess(null, null, "df1"));
+        pathToDockerfilesInParentRepo.put("repo2", new GitHubContentToProcess(null, null, "df2"));
+        pathToDockerfilesInParentRepo.put("repo3", new GitHubContentToProcess(null, null, "df3"));
+        pathToDockerfilesInParentRepo.put("repo4", new GitHubContentToProcess(null, null, "df4"));
 
         GHContent content = mock(GHContent.class);
 
@@ -224,7 +224,7 @@ public class ParentTest {
 
         Parent parent = new Parent();
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        parent.changeDockerfiles(ns, pathToDockerfilesInParentRepo, new ForkWithContentPath(forkedRepo, parentRepo, ""), new ArrayList<>());
+        parent.changeDockerfiles(ns, pathToDockerfilesInParentRepo, new GitHubContentToProcess(forkedRepo, parentRepo, ""), new ArrayList<>());
 
         Mockito.verify(dockerfileGitHubUtil, times(1))
                 .tryRetrievingContent(eq(forkedRepo), eq("df2"), eq("image-tag"));
@@ -242,11 +242,11 @@ public class ParentTest {
                 "store");
         Namespace ns = new Namespace(nsMap);
 
-        Multimap<String, ForkWithContentPath> pathToDockerfilesInParentRepo = HashMultimap.create();
-        pathToDockerfilesInParentRepo.put("repo1", new ForkWithContentPath(null, null, "df11"));
-        pathToDockerfilesInParentRepo.put("repo1", new ForkWithContentPath(null, null, "df12"));
-        pathToDockerfilesInParentRepo.put("repo3", new ForkWithContentPath(null, null, "df3"));
-        pathToDockerfilesInParentRepo.put("repo4", new ForkWithContentPath(null, null, "df4"));
+        Multimap<String, GitHubContentToProcess> pathToDockerfilesInParentRepo = HashMultimap.create();
+        pathToDockerfilesInParentRepo.put("repo1", new GitHubContentToProcess(null, null, "df11"));
+        pathToDockerfilesInParentRepo.put("repo1", new GitHubContentToProcess(null, null, "df12"));
+        pathToDockerfilesInParentRepo.put("repo3", new GitHubContentToProcess(null, null, "df3"));
+        pathToDockerfilesInParentRepo.put("repo4", new GitHubContentToProcess(null, null, "df4"));
 
         GHRepository forkedRepo = mock(GHRepository.class);
         when(forkedRepo.isFork()).thenReturn(true);
@@ -268,7 +268,7 @@ public class ParentTest {
 
         Parent parent = new Parent();
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        parent.changeDockerfiles(ns, pathToDockerfilesInParentRepo, new ForkWithContentPath(forkedRepo, parentRepo, ""), new ArrayList<>());
+        parent.changeDockerfiles(ns, pathToDockerfilesInParentRepo, new GitHubContentToProcess(forkedRepo, parentRepo, ""), new ArrayList<>());
 
         // Both Dockerfiles retrieved from the same repo
         Mockito.verify(dockerfileGitHubUtil, times(1)).tryRetrievingContent(eq(forkedRepo),
@@ -293,8 +293,8 @@ public class ParentTest {
                 "store");
         Namespace ns = new Namespace(nsMap);
 
-        Multimap<String, ForkWithContentPath> pathToDockerfilesInParentRepo = HashMultimap.create();
-        pathToDockerfilesInParentRepo.put("repo1", new ForkWithContentPath(null, null, "missing_df"));
+        Multimap<String, GitHubContentToProcess> pathToDockerfilesInParentRepo = HashMultimap.create();
+        pathToDockerfilesInParentRepo.put("repo1", new GitHubContentToProcess(null, null, "missing_df"));
 
         GHRepository forkedRepo = mock(GHRepository.class);
         when(forkedRepo.isFork()).thenReturn(true);
@@ -312,7 +312,7 @@ public class ParentTest {
 
         Parent parent = new Parent();
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        parent.changeDockerfiles(ns, pathToDockerfilesInParentRepo, new ForkWithContentPath(forkedRepo, parentRepo, ""), new ArrayList<>());
+        parent.changeDockerfiles(ns, pathToDockerfilesInParentRepo, new GitHubContentToProcess(forkedRepo, parentRepo, ""), new ArrayList<>());
 
         // trying to retrieve Dockerfile
         Mockito.verify(dockerfileGitHubUtil, times(1)).tryRetrievingContent(eq(forkedRepo),
@@ -345,7 +345,7 @@ public class ParentTest {
 
         Parent parent = new Parent();
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        Multimap<String, ForkWithContentPath> pathToDockerfiles = parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
+        Multimap<String, GitHubContentToProcess> pathToDockerfiles = parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
         assertTrue(pathToDockerfiles.isEmpty());
         Mockito.verify(dockerfileGitHubUtil, times(0)).getOrCreateFork(any());
     }

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ParentTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ParentTest.java
@@ -11,21 +11,22 @@ package com.salesforce.dockerfileimageupdate.subcommands.impl;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
+import com.salesforce.dockerfileimageupdate.subcommands.impl.Parent.ForkWithContentPath;
 import com.salesforce.dockerfileimageupdate.utils.Constants;
 import com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil;
 import net.sourceforge.argparse4j.inf.Namespace;
-import org.kohsuke.github.*;
+import org.kohsuke.github.GHContent;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.PagedIterator;
+import org.kohsuke.github.PagedSearchIterable;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
-import java.io.FileNotFoundException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 
@@ -99,13 +100,14 @@ public class ParentTest {
         when(contentsWithImageIterator.next()).thenReturn(content1, content2, content3, null);
         when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
 
-        when(dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(Mockito.any())).thenReturn(new GHRepository());
+        when(dockerfileGitHubUtil.getOrCreateFork(Mockito.any())).thenReturn(new GHRepository());
+        when(dockerfileGitHubUtil.getRepo(any())).thenReturn(mock(GHRepository.class));
 
         Parent parent = new Parent();
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        Multimap<String, String> repoMap =  parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
+        Multimap<String, ForkWithContentPath> repoMap =  parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
 
-        verify(dockerfileGitHubUtil, times(3)).getForkAndEnsureTargetBranchExistsFromDesiredBranch(any());
+        verify(dockerfileGitHubUtil, times(3)).getOrCreateFork(any());
         assertEquals(repoMap.size(), 3);
     }
 
@@ -148,16 +150,19 @@ public class ParentTest {
         when(contentsWithImageIterator.hasNext()).thenReturn(true, true, true, false);
         when(contentsWithImageIterator.next()).thenReturn(content1, content2, content3, null);
         when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
-        when(dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(contentRepo1)).thenReturn(null); // repo1 is unforkable
-        when(dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(duplicateContentRepo1)).thenReturn(null); // repo1 is unforkable
-        when(dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(contentRepo2)).thenReturn(new GHRepository());
+        when(dockerfileGitHubUtil.getOrCreateFork(contentRepo1)).thenReturn(null); // repo1 is unforkable
+        when(dockerfileGitHubUtil.getOrCreateFork(duplicateContentRepo1)).thenReturn(null); // repo1 is unforkable
+        when(dockerfileGitHubUtil.getOrCreateFork(contentRepo2)).thenReturn(mock(GHRepository.class));
+        when(dockerfileGitHubUtil.getRepo(contentRepo1.getFullName())).thenReturn(contentRepo1);
+        when(dockerfileGitHubUtil.getRepo(duplicateContentRepo1.getFullName())).thenReturn(duplicateContentRepo1);
+        when(dockerfileGitHubUtil.getRepo(contentRepo2.getFullName())).thenReturn(contentRepo2);
 
         Parent parent = new Parent();
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        Multimap<String, String> repoMap =  parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
+        Multimap<String, ForkWithContentPath> repoMap =  parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
 
         // Since repo "1" is unforkable, we will only try to update repo "2"
-        verify(dockerfileGitHubUtil, times(3)).getForkAndEnsureTargetBranchExistsFromDesiredBranch(any());
+        verify(dockerfileGitHubUtil, times(3)).getOrCreateFork(any());
         assertEquals(repoMap.size(), 1);
     }
 
@@ -179,82 +184,14 @@ public class ParentTest {
         when(contentsWithImageIterator.next()).thenReturn(content1, null);
         when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
 
+        when(dockerfileGitHubUtil.getRepo(any())).thenReturn(contentRepo1);
+
         Parent parent = new Parent();
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        Multimap<String, String> repoMap = parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
+        Multimap<String, ForkWithContentPath> repoMap = parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
 
-        verify(dockerfileGitHubUtil, never()).getForkAndEnsureTargetBranchExistsFromDesiredBranch(any());
+        verify(dockerfileGitHubUtil, never()).getOrCreateFork(any());
         assertEquals(repoMap.size(), 0);
-    }
-
-    @Test
-    public void testChangeDockerfiles_returnIfNotFork() throws Exception {
-        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
-        GHRepository currUserRepo = mock(GHRepository.class);
-        when(currUserRepo.isFork()).thenReturn(false);
-
-        Parent parent = new Parent();
-        parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        parent.changeDockerfiles(null, null, currUserRepo, new ArrayList<>());
-
-        verify(dockerfileGitHubUtil, times(0)).getRepo(anyString());
-    }
-
-    @Test
-    public void testChangeDockerfiles_returnIfNotDesiredParent() throws Exception {
-        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
-
-        GHRepository currUserRepo = mock(GHRepository.class);
-        when(currUserRepo.isFork()).thenReturn(true);
-        when(currUserRepo.getFullName()).thenReturn("forkedrepo5");
-
-        GHRepository forkedRepo = mock(GHRepository.class);
-        GHRepository parentRepo = mock(GHRepository.class);
-        when(parentRepo.getFullName()).thenReturn("repo5");
-        when(forkedRepo.getParent()).thenReturn(parentRepo);
-        when(forkedRepo.getDefaultBranch()).thenReturn("branch");
-
-        when(dockerfileGitHubUtil.getRepo(currUserRepo.getFullName())).thenReturn(forkedRepo);
-
-        Multimap<String, String> pathToDockerfilesInParentRepo = HashMultimap.create();
-        pathToDockerfilesInParentRepo.put("repo1", "df1");
-        pathToDockerfilesInParentRepo.put("repo2", "df2");
-        pathToDockerfilesInParentRepo.put("repo3", "df3");
-        pathToDockerfilesInParentRepo.put("repo4", "df4");
-
-        Parent parent = new Parent();
-        parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        parent.changeDockerfiles(null, pathToDockerfilesInParentRepo, currUserRepo, new ArrayList<>());
-
-        verify(dockerfileGitHubUtil, times(1)).getRepo(eq(currUserRepo.getFullName()));
-        verify(dockerfileGitHubUtil, times(0))
-                .tryRetrievingContent(eq(forkedRepo), anyString(), anyString());
-        verify(dockerfileGitHubUtil, times(0))
-                .modifyOnGithub(any(), anyString(), anyString(), anyString(), anyString());
-        verify(dockerfileGitHubUtil, times(0))
-                .createPullReq(eq(parentRepo), anyString(), eq(forkedRepo), anyString());
-    }
-
-    @Test
-    public void testChangeDockerfiles_returnWhenForkedRepoNotFound() throws Exception {
-
-        GHRepository currUserRepo = mock(GHRepository.class);
-        when(currUserRepo.isFork()).thenReturn(true);
-
-        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
-        when(dockerfileGitHubUtil.getRepo(currUserRepo.getFullName())).thenThrow(FileNotFoundException.class);
-
-        Parent parent = new Parent();
-        parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        parent.changeDockerfiles(null, null, currUserRepo, new ArrayList<>());
-
-        Mockito.verify(dockerfileGitHubUtil, times(1)).getRepo(anyString());
-        Mockito.verify(dockerfileGitHubUtil, times(0)).tryRetrievingContent(any(),
-                anyString(), anyString());
-        Mockito.verify(dockerfileGitHubUtil, times(0))
-                .modifyOnGithub(any(), anyString(), anyString(), anyString(), anyString());
-        Mockito.verify(dockerfileGitHubUtil, times(0)).createPullReq(any(), anyString(), any(), anyString());
-
     }
 
     @Test
@@ -262,43 +199,39 @@ public class ParentTest {
         Map<String, Object> nsMap = ImmutableMap.of(Constants.IMG, "image", Constants.TAG, "tag", Constants.STORE, "store");
         Namespace ns = new Namespace(nsMap);
 
-        GHRepository currUserRepo = mock(GHRepository.class);
-        when(currUserRepo.isFork()).thenReturn(true);
-        when(currUserRepo.getFullName()).thenReturn("forkedrepo");
-
         GHRepository forkedRepo = mock(GHRepository.class);
+        when(forkedRepo.isFork()).thenReturn(true);
+        when(forkedRepo.getFullName()).thenReturn("forkedrepo");
+
         GHRepository parentRepo = mock(GHRepository.class);
         when(parentRepo.getFullName()).thenReturn("repo2");
         when(forkedRepo.getParent()).thenReturn(parentRepo);
-        when(forkedRepo.getFullName()).thenReturn("forkedrepo");
-        when(forkedRepo.getDefaultBranch()).thenReturn("branch");
 
-        Multimap<String, String> pathToDockerfilesInParentRepo = HashMultimap.create();
-        pathToDockerfilesInParentRepo.put("repo1", "df1");
-        pathToDockerfilesInParentRepo.put("repo2", "df2");
-        pathToDockerfilesInParentRepo.put("repo3", "df3");
-        pathToDockerfilesInParentRepo.put("repo4", "df4");
+        Multimap<String, ForkWithContentPath> pathToDockerfilesInParentRepo = HashMultimap.create();
+        pathToDockerfilesInParentRepo.put("repo1", new ForkWithContentPath(null, null, "df1"));
+        pathToDockerfilesInParentRepo.put("repo2", new ForkWithContentPath(null, null, "df2"));
+        pathToDockerfilesInParentRepo.put("repo3", new ForkWithContentPath(null, null, "df3"));
+        pathToDockerfilesInParentRepo.put("repo4", new ForkWithContentPath(null, null, "df4"));
 
         GHContent content = mock(GHContent.class);
-        when(content.getOwner()).thenReturn(forkedRepo);
 
         DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
-        when(dockerfileGitHubUtil.getRepo(currUserRepo.getFullName())).thenReturn(forkedRepo);
+
+        when(dockerfileGitHubUtil.getPullRequestForImageBranch(eq(forkedRepo), any())).thenReturn(Optional.empty());
 
         when(dockerfileGitHubUtil.tryRetrievingContent(forkedRepo, "df2",
-                forkedRepo.getDefaultBranch())).thenReturn(content);
+                "image-tag")).thenReturn(content);
 
         Parent parent = new Parent();
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        parent.changeDockerfiles(ns, pathToDockerfilesInParentRepo, currUserRepo, new ArrayList<>());
+        parent.changeDockerfiles(ns, pathToDockerfilesInParentRepo, new ForkWithContentPath(forkedRepo, parentRepo, ""), new ArrayList<>());
 
-        Mockito.verify(dockerfileGitHubUtil, times(1)).getRepo(anyString());
         Mockito.verify(dockerfileGitHubUtil, times(1))
-                .tryRetrievingContent(eq(forkedRepo), eq("df2"), eq("branch"));
+                .tryRetrievingContent(eq(forkedRepo), eq("df2"), eq("image-tag"));
         Mockito.verify(dockerfileGitHubUtil, times(1))
-                .modifyOnGithub(eq(content), eq("branch"), eq("image"), eq("tag"), anyString());
+                .modifyOnGithub(eq(content), eq("image-tag"), eq("image"), eq("tag"), anyString());
         Mockito.verify(dockerfileGitHubUtil, times(1))
-                .createPullReq(eq(parentRepo), eq("branch"), eq(forkedRepo), anyString());
+                .createPullReq(eq(parentRepo), eq("image-tag"), eq(forkedRepo), anyString());
     }
 
     @Test
@@ -309,51 +242,47 @@ public class ParentTest {
                 "store");
         Namespace ns = new Namespace(nsMap);
 
-        Multimap<String, String> pathToDockerfilesInParentRepo = HashMultimap.create();
-        pathToDockerfilesInParentRepo.put("repo1", "df11");
-        pathToDockerfilesInParentRepo.put("repo1", "df12");
-        pathToDockerfilesInParentRepo.put("repo3", "df3");
-        pathToDockerfilesInParentRepo.put("repo4", "df4");
-
-        GHRepository currUserRepo = mock(GHRepository.class);
-        when(currUserRepo.isFork()).thenReturn(true);
-        when(currUserRepo.getFullName()).thenReturn("forkedrepo");
+        Multimap<String, ForkWithContentPath> pathToDockerfilesInParentRepo = HashMultimap.create();
+        pathToDockerfilesInParentRepo.put("repo1", new ForkWithContentPath(null, null, "df11"));
+        pathToDockerfilesInParentRepo.put("repo1", new ForkWithContentPath(null, null, "df12"));
+        pathToDockerfilesInParentRepo.put("repo3", new ForkWithContentPath(null, null, "df3"));
+        pathToDockerfilesInParentRepo.put("repo4", new ForkWithContentPath(null, null, "df4"));
 
         GHRepository forkedRepo = mock(GHRepository.class);
+        when(forkedRepo.isFork()).thenReturn(true);
+        when(forkedRepo.getFullName()).thenReturn("forkedrepo");
+
         GHRepository parentRepo = mock(GHRepository.class);
         when(parentRepo.getFullName()).thenReturn("repo1");
         when(forkedRepo.getParent()).thenReturn(parentRepo);
-        when(forkedRepo.getDefaultBranch()).thenReturn("branch");
 
         DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
-        when(dockerfileGitHubUtil.getRepo(currUserRepo.getFullName())).thenReturn(forkedRepo);
+        when(dockerfileGitHubUtil.getPullRequestForImageBranch(any(), any())).thenReturn(Optional.empty());
+        when(dockerfileGitHubUtil.getRepo(forkedRepo.getFullName())).thenReturn(forkedRepo);
         GHContent forkedRepoContent1 = mock(GHContent.class);
         when(dockerfileGitHubUtil.tryRetrievingContent(eq(forkedRepo),
-                eq("df11"), eq("branch"))).thenReturn(forkedRepoContent1);
+                eq("df11"), eq("image-tag"))).thenReturn(forkedRepoContent1);
         GHContent forkedRepoContent2 = mock(GHContent.class);
         when(dockerfileGitHubUtil.tryRetrievingContent(eq(forkedRepo),
-                eq("df12"), eq("branch"))).thenReturn(forkedRepoContent2);
+                eq("df12"), eq("image-tag"))).thenReturn(forkedRepoContent2);
 
         Parent parent = new Parent();
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        parent.changeDockerfiles(ns, pathToDockerfilesInParentRepo, currUserRepo, new ArrayList<>());
-
-        // Get repo only once
-        Mockito.verify(dockerfileGitHubUtil, times(1)).getRepo(anyString());
+        parent.changeDockerfiles(ns, pathToDockerfilesInParentRepo, new ForkWithContentPath(forkedRepo, parentRepo, ""), new ArrayList<>());
 
         // Both Dockerfiles retrieved from the same repo
         Mockito.verify(dockerfileGitHubUtil, times(1)).tryRetrievingContent(eq(forkedRepo),
-                eq("df11"), eq("branch"));
+                eq("df11"), eq("image-tag"));
         Mockito.verify(dockerfileGitHubUtil, times(1)).tryRetrievingContent(eq(forkedRepo),
-                eq("df12"), eq("branch"));
+                eq("df12"), eq("image-tag"));
 
         // Both Dockerfiles modified
         Mockito.verify(dockerfileGitHubUtil, times(2))
-                .modifyOnGithub(any(), eq("branch"), eq("image"), eq("tag"), anyString());
+                .modifyOnGithub(any(), eq("image-tag"), eq("image"), eq("tag"), anyString());
 
         // Only one PR created on the repo with changes to both Dockerfiles.
         Mockito.verify(dockerfileGitHubUtil, times(1)).createPullReq(eq(parentRepo),
-                eq("branch"), eq(forkedRepo), anyString());
+                eq("image-tag"), eq(forkedRepo), anyString());
     }
 
     @Test
@@ -364,36 +293,30 @@ public class ParentTest {
                 "store");
         Namespace ns = new Namespace(nsMap);
 
-        Multimap<String, String> pathToDockerfilesInParentRepo = HashMultimap.create();
-        pathToDockerfilesInParentRepo.put("repo1", "missing_df");
-
-        GHRepository currUserRepo = mock(GHRepository.class);
-        when(currUserRepo.isFork()).thenReturn(true);
-        when(currUserRepo.getFullName()).thenReturn("forkedrepo");
+        Multimap<String, ForkWithContentPath> pathToDockerfilesInParentRepo = HashMultimap.create();
+        pathToDockerfilesInParentRepo.put("repo1", new ForkWithContentPath(null, null, "missing_df"));
 
         GHRepository forkedRepo = mock(GHRepository.class);
+        when(forkedRepo.isFork()).thenReturn(true);
+        when(forkedRepo.getFullName()).thenReturn("forkedrepo");
+
         GHRepository parentRepo = mock(GHRepository.class);
         when(parentRepo.getFullName()).thenReturn("repo1");
         when(forkedRepo.getParent()).thenReturn(parentRepo);
-        when(forkedRepo.getFullName()).thenReturn("forkedrepo");
-        when(forkedRepo.getDefaultBranch()).thenReturn("branch");
 
         DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
-        when(dockerfileGitHubUtil.getRepo(currUserRepo.getFullName())).thenReturn(forkedRepo);
+        when(dockerfileGitHubUtil.getPullRequestForImageBranch(any(), any())).thenReturn(Optional.empty());
         // Dockerfile not found anymore when trying to retrieve contents from the forked repo.
         when(dockerfileGitHubUtil.tryRetrievingContent(eq(forkedRepo),
-                eq("missing_df"), eq("branch"))).thenReturn(null);
+                eq("missing_df"), eq("image-tag"))).thenReturn(null);
 
         Parent parent = new Parent();
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        parent.changeDockerfiles(ns, pathToDockerfilesInParentRepo, currUserRepo, new ArrayList<>());
-
-        // fetch repo
-        Mockito.verify(dockerfileGitHubUtil, times(1)).getRepo(anyString());
+        parent.changeDockerfiles(ns, pathToDockerfilesInParentRepo, new ForkWithContentPath(forkedRepo, parentRepo, ""), new ArrayList<>());
 
         // trying to retrieve Dockerfile
         Mockito.verify(dockerfileGitHubUtil, times(1)).tryRetrievingContent(eq(forkedRepo),
-                eq("missing_df"), eq("branch"));
+                eq("missing_df"), eq("image-tag"));
 
         // missing Dockerfile, so skipping modify and create PR
         Mockito.verify(dockerfileGitHubUtil, times(0))
@@ -418,48 +341,58 @@ public class ParentTest {
         when(contentsWithImageIterator.next()).thenReturn(content, null);
         when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
 
+        when(dockerfileGitHubUtil.getRepo(any())).thenReturn(parentRepo);
+
         Parent parent = new Parent();
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        Multimap<String, String> pathToDockerfiles = parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
+        Multimap<String, ForkWithContentPath> pathToDockerfiles = parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
         assertTrue(pathToDockerfiles.isEmpty());
-        Mockito.verify(dockerfileGitHubUtil, times(0)).getForkAndEnsureTargetBranchExistsFromDesiredBranch(any());
+        Mockito.verify(dockerfileGitHubUtil, times(0)).getOrCreateFork(any());
     }
-
-    @Test
-    public void checkPullRequestNotMadeForArchived() throws Exception {
-        final String repoName = "mock repo";
-        Map<String, Object> nsMap = ImmutableMap.of(Constants.IMG,
-                "image", Constants.TAG,
-                "tag", Constants.STORE,
-                "store");
-        Namespace ns = new Namespace(nsMap);
-
-        GHRepository parentRepo = mock(GHRepository.class);
-        GHRepository forkRepo = mock(GHRepository.class);
-        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
-        GHContent content = mock(GHContent.class);
-        GHMyself myself = mock(GHMyself.class);
-
-        when(parentRepo.isArchived()).thenReturn(true);
-
-        when(parentRepo.getFullName()).thenReturn(repoName);
-        when(forkRepo.getFullName()).thenReturn(repoName);
-        when(content.getOwner()).thenReturn(parentRepo);
-        when(dockerfileGitHubUtil.getRepo(eq(repoName))).thenReturn(forkRepo);
-        when(forkRepo.isFork()).thenReturn(true);
-        when(forkRepo.getParent()).thenReturn(parentRepo);
-        when(dockerfileGitHubUtil.getMyself()).thenReturn(myself);
-
-        Multimap<String, String> pathToDockerfilesInParentRepo = HashMultimap.create();
-        pathToDockerfilesInParentRepo.put(repoName, null);
-
-        Parent parent = new Parent();
-        parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        parent.changeDockerfiles(ns, pathToDockerfilesInParentRepo, forkRepo, Collections.emptyList());
-
-        Mockito.verify(dockerfileGitHubUtil, Mockito.never())
-                .createPullReq(Mockito.any(), anyString(), Mockito.any(), anyString());
-        //Make sure we at least call the isArchived.
-        Mockito.verify(parentRepo, Mockito.times(2)).isArchived();
-    }
+// TODO: COVER THIS SCENARIO
+//    @Test
+//    public void checkPullRequestNotMadeForArchived() throws Exception {
+//        final String repoName = "mock repo";
+//        Map<String, Object> nsMap = ImmutableMap.of(Constants.IMG,
+//                "image", Constants.TAG,
+//                "tag", Constants.STORE,
+//                "store");
+//        Namespace ns = new Namespace(nsMap);
+//
+//        GHRepository parentRepo = mock(GHRepository.class);
+//        GHRepository forkRepo = mock(GHRepository.class);
+//        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+//        GHContent content = mock(GHContent.class);
+//        GHMyself myself = mock(GHMyself.class);
+//
+//        when(parentRepo.isArchived()).thenReturn(true);
+//
+//        when(parentRepo.getFullName()).thenReturn(repoName);
+//        when(forkRepo.getFullName()).thenReturn(repoName);
+//        when(content.getOwner()).thenReturn(parentRepo);
+//        when(dockerfileGitHubUtil.getRepo(eq(repoName))).thenReturn(forkRepo);
+//        when(forkRepo.isFork()).thenReturn(true);
+//        when(forkRepo.getParent()).thenReturn(parentRepo);
+//        when(dockerfileGitHubUtil.getMyself()).thenReturn(myself);
+//        when(dockerfileGitHubUtil.getPullRequestForImageBranch(any(), any())).thenReturn(Optional.empty());
+//
+//        Multimap<String, ForkWithContentPath> pathToDockerfilesInParentRepo = HashMultimap.create();
+//        pathToDockerfilesInParentRepo.put(repoName, null);
+//
+//        Parent parent = new Parent();
+//        parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
+//        PagedSearchIterable<GHContent> results = mock(PagedSearchIterable.class);
+//        PagedIterator<GHContent> iterator = mock(PagedIterator.class);
+//        when(results.iterator()).thenReturn(iterator);
+//        when(iterator.hasNext()).thenReturn(true, false);
+//        when(iterator.next()).thenReturn(content);
+////        Multimap<String, ForkWithContentPath> forks = parent.forkRepositoriesFoundAndGetPathToDockerfiles(results);
+//        parent.changeDockerfiles(ns, pathToDockerfilesInParentRepo, forkRepo, Collections.emptyList());
+//
+//        Mockito.verify(dockerfileGitHubUtil, Mockito.never())
+//                .createPullReq(Mockito.any(), anyString(), Mockito.any(), anyString());
+//        //Make sure we at least call the isArchived.
+//        Mockito.verify(parentRepo, Mockito.times(1)).isArchived();
+////        assertTrue(forks.isEmpty());
+//    }
 }

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ParentTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ParentTest.java
@@ -34,46 +34,6 @@ import static org.testng.Assert.*;
  * Created by minho.park on 7/19/16.
  */
 public class ParentTest {
-
-    @Test
-    public void testGetGHContents() throws Exception {
-        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
-
-        Parent parent = new Parent();
-
-        GHContent content1 = mock(GHContent.class);
-        GHContent content2 = mock(GHContent.class);
-        GHContent content3 = mock(GHContent.class);
-
-        PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
-        when(contentsWithImage.getTotalCount()).thenReturn(3);
-
-        PagedIterator<GHContent> contentsWithImageIterator = mock(PagedIterator.class);
-        when(contentsWithImageIterator.hasNext()).thenReturn(true, true, true, false);
-        when(contentsWithImageIterator.next()).thenReturn(content1, content2, content3, null);
-        when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
-
-        when(dockerfileGitHubUtil.findFilesWithImage(anyString(), eq("org"))).thenReturn(contentsWithImage);
-
-        parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-
-        assertEquals(parent.getGHContents("org", "image"), contentsWithImage);
-    }
-
-    @Test
-    public void testGHContentsNoOutput() throws Exception {
-        Parent parent = new Parent();
-
-        PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
-        when(contentsWithImage.getTotalCount()).thenReturn(0);
-
-        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
-        when(dockerfileGitHubUtil.findFilesWithImage(anyString(), eq("org"))).thenReturn(contentsWithImage);
-        parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-
-        assertNull(parent.getGHContents("org", "image"));
-    }
-
     @Test
     public void testForkRepositoriesFound() throws Exception {
         DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ParentTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ParentTest.java
@@ -17,8 +17,6 @@ import com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.kohsuke.github.GHContent;
 import org.kohsuke.github.GHRepository;
-import org.kohsuke.github.PagedIterator;
-import org.kohsuke.github.PagedSearchIterable;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -28,131 +26,11 @@ import java.util.Optional;
 
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
 
 /**
  * Created by minho.park on 7/19/16.
  */
 public class ParentTest {
-    @Test
-    public void testForkRepositoriesFound() throws Exception {
-        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
-
-        GHRepository contentRepo1 = mock(GHRepository.class);
-        when(contentRepo1.getFullName()).thenReturn("1");
-        GHRepository contentRepo2 = mock(GHRepository.class);
-        when(contentRepo2.getFullName()).thenReturn("2");
-        GHRepository contentRepo3 = mock(GHRepository.class);
-        when(contentRepo3.getFullName()).thenReturn("3");
-
-
-        GHContent content1 = mock(GHContent.class);
-        when(content1.getOwner()).thenReturn(contentRepo1);
-        GHContent content2 = mock(GHContent.class);
-        when(content2.getOwner()).thenReturn(contentRepo2);
-        GHContent content3 = mock(GHContent.class);
-        when(content3.getOwner()).thenReturn(contentRepo3);
-
-        PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
-
-        PagedIterator<GHContent> contentsWithImageIterator = mock(PagedIterator.class);
-        when(contentsWithImageIterator.hasNext()).thenReturn(true, true, true, false);
-        when(contentsWithImageIterator.next()).thenReturn(content1, content2, content3, null);
-        when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
-
-        when(dockerfileGitHubUtil.getOrCreateFork(Mockito.any())).thenReturn(new GHRepository());
-        when(dockerfileGitHubUtil.getRepo(any())).thenReturn(mock(GHRepository.class));
-
-        Parent parent = new Parent();
-        parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        Multimap<String, GitHubContentToProcess> repoMap =  parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
-
-        verify(dockerfileGitHubUtil, times(3)).getOrCreateFork(any());
-        assertEquals(repoMap.size(), 3);
-    }
-
-    @Test
-    public void forkRepositoriesFoundAndGetPathToDockerfiles_unableToforkRepo() throws Exception {
-        /**
-         * Suppose we have multiple dockerfiles that need to updated in a repo and we fail to fork such repo,
-         * we should not add those repos to pathToDockerfilesInParentRepo.
-         *
-         * Note: Sometimes GitHub search API returns the same result twice. This test covers such cases as well.
-         */
-        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
-
-        GHRepository contentRepo1 = mock(GHRepository.class);
-        when(contentRepo1.getFullName()).thenReturn("1");
-
-        GHRepository duplicateContentRepo1 = mock(GHRepository.class);
-        // Say we have multiple dockerfiles to be updated in repo "1"
-        // Or sometimes GitHub search API returns same result twice.
-        when(duplicateContentRepo1.getFullName()).thenReturn("1");
-
-        GHRepository contentRepo2 = mock(GHRepository.class);
-        when(contentRepo2.getFullName()).thenReturn("2");
-
-        GHContent content1 = mock(GHContent.class);
-        when(content1.getOwner()).thenReturn(contentRepo1);
-        when(content1.getPath()).thenReturn("1"); // path to 1st dockerfile in repo "1"
-
-        GHContent content2 = mock(GHContent.class);
-        when(content2.getOwner()).thenReturn(duplicateContentRepo1);
-        when(content2.getPath()).thenReturn("2"); // path to 2st dockerfile in repo "1"
-
-        GHContent content3 = mock(GHContent.class);
-        when(content3.getOwner()).thenReturn(contentRepo2);
-        when(content3.getPath()).thenReturn("3");
-
-        PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
-
-        PagedIterator<GHContent> contentsWithImageIterator = mock(PagedIterator.class);
-        when(contentsWithImageIterator.hasNext()).thenReturn(true, true, true, false);
-        when(contentsWithImageIterator.next()).thenReturn(content1, content2, content3, null);
-        when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
-        when(dockerfileGitHubUtil.getOrCreateFork(contentRepo1)).thenReturn(null); // repo1 is unforkable
-        when(dockerfileGitHubUtil.getOrCreateFork(duplicateContentRepo1)).thenReturn(null); // repo1 is unforkable
-        when(dockerfileGitHubUtil.getOrCreateFork(contentRepo2)).thenReturn(mock(GHRepository.class));
-        when(dockerfileGitHubUtil.getRepo(contentRepo1.getFullName())).thenReturn(contentRepo1);
-        when(dockerfileGitHubUtil.getRepo(duplicateContentRepo1.getFullName())).thenReturn(duplicateContentRepo1);
-        when(dockerfileGitHubUtil.getRepo(contentRepo2.getFullName())).thenReturn(contentRepo2);
-
-        Parent parent = new Parent();
-        parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        Multimap<String, GitHubContentToProcess> repoMap =  parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
-
-        // Since repo "1" is unforkable, we will only try to update repo "2"
-        verify(dockerfileGitHubUtil, times(3)).getOrCreateFork(any());
-        assertEquals(repoMap.size(), 1);
-    }
-
-    @Test
-    public void testForkRepositoriesFound_forkRepoIsSkipped() throws Exception {
-        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
-
-        GHRepository contentRepo1 = mock(GHRepository.class);
-        when(contentRepo1.getFullName()).thenReturn("1");
-
-        GHContent content1 = mock(GHContent.class);
-        when(content1.getOwner()).thenReturn(contentRepo1);
-        when(contentRepo1.isFork()).thenReturn(true);
-
-        PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
-
-        PagedIterator<GHContent> contentsWithImageIterator = mock(PagedIterator.class);
-        when(contentsWithImageIterator.hasNext()).thenReturn(true, false);
-        when(contentsWithImageIterator.next()).thenReturn(content1, null);
-        when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
-
-        when(dockerfileGitHubUtil.getRepo(any())).thenReturn(contentRepo1);
-
-        Parent parent = new Parent();
-        parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        Multimap<String, GitHubContentToProcess> repoMap = parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
-
-        verify(dockerfileGitHubUtil, never()).getOrCreateFork(any());
-        assertEquals(repoMap.size(), 0);
-    }
 
     @Test
     public void testChangeDockerfiles_pullRequestCreation() throws Exception {
@@ -284,75 +162,4 @@ public class ParentTest {
         Mockito.verify(dockerfileGitHubUtil, times(0)).createPullReq(eq(parentRepo),
                 anyString(), eq(forkedRepo), anyString());
     }
-
-    @Test
-    public void testPullRequestToAForkIsUnSupported() throws Exception {
-
-        GHRepository parentRepo = mock(GHRepository.class);
-        // When the repo is a fork then skip it.
-        when(parentRepo.isFork()).thenReturn(true);
-        GHContent content = mock(GHContent.class);
-        when(content.getOwner()).thenReturn(parentRepo);
-
-        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
-        PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
-        PagedIterator<GHContent> contentsWithImageIterator = mock(PagedIterator.class);
-        when(contentsWithImageIterator.hasNext()).thenReturn(true, false);
-        when(contentsWithImageIterator.next()).thenReturn(content, null);
-        when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
-
-        when(dockerfileGitHubUtil.getRepo(any())).thenReturn(parentRepo);
-
-        Parent parent = new Parent();
-        parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-        Multimap<String, GitHubContentToProcess> pathToDockerfiles = parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
-        assertTrue(pathToDockerfiles.isEmpty());
-        Mockito.verify(dockerfileGitHubUtil, times(0)).getOrCreateFork(any());
-    }
-// TODO: COVER THIS SCENARIO
-//    @Test
-//    public void checkPullRequestNotMadeForArchived() throws Exception {
-//        final String repoName = "mock repo";
-//        Map<String, Object> nsMap = ImmutableMap.of(Constants.IMG,
-//                "image", Constants.TAG,
-//                "tag", Constants.STORE,
-//                "store");
-//        Namespace ns = new Namespace(nsMap);
-//
-//        GHRepository parentRepo = mock(GHRepository.class);
-//        GHRepository forkRepo = mock(GHRepository.class);
-//        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
-//        GHContent content = mock(GHContent.class);
-//        GHMyself myself = mock(GHMyself.class);
-//
-//        when(parentRepo.isArchived()).thenReturn(true);
-//
-//        when(parentRepo.getFullName()).thenReturn(repoName);
-//        when(forkRepo.getFullName()).thenReturn(repoName);
-//        when(content.getOwner()).thenReturn(parentRepo);
-//        when(dockerfileGitHubUtil.getRepo(eq(repoName))).thenReturn(forkRepo);
-//        when(forkRepo.isFork()).thenReturn(true);
-//        when(forkRepo.getParent()).thenReturn(parentRepo);
-//        when(dockerfileGitHubUtil.getMyself()).thenReturn(myself);
-//        when(dockerfileGitHubUtil.getPullRequestForImageBranch(any(), any())).thenReturn(Optional.empty());
-//
-//        Multimap<String, ForkWithContentPath> pathToDockerfilesInParentRepo = HashMultimap.create();
-//        pathToDockerfilesInParentRepo.put(repoName, null);
-//
-//        Parent parent = new Parent();
-//        parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
-//        PagedSearchIterable<GHContent> results = mock(PagedSearchIterable.class);
-//        PagedIterator<GHContent> iterator = mock(PagedIterator.class);
-//        when(results.iterator()).thenReturn(iterator);
-//        when(iterator.hasNext()).thenReturn(true, false);
-//        when(iterator.next()).thenReturn(content);
-////        Multimap<String, ForkWithContentPath> forks = parent.forkRepositoriesFoundAndGetPathToDockerfiles(results);
-//        parent.changeDockerfiles(ns, pathToDockerfilesInParentRepo, forkRepo, Collections.emptyList());
-//
-//        Mockito.verify(dockerfileGitHubUtil, Mockito.never())
-//                .createPullReq(Mockito.any(), anyString(), Mockito.any(), anyString());
-//        //Make sure we at least call the isArchived.
-//        Mockito.verify(parentRepo, Mockito.times(1)).isArchived();
-////        assertTrue(forks.isEmpty());
-//    }
 }

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ParentTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ParentTest.java
@@ -99,13 +99,13 @@ public class ParentTest {
         when(contentsWithImageIterator.next()).thenReturn(content1, content2, content3, null);
         when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
 
-        when(dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(Mockito.any())).thenReturn(new GHRepository());
+        when(dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(Mockito.any())).thenReturn(new GHRepository());
 
         Parent parent = new Parent();
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
         Multimap<String, String> repoMap =  parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
 
-        verify(dockerfileGitHubUtil, times(3)).closeOutdatedPullRequestAndFork(any());
+        verify(dockerfileGitHubUtil, times(3)).getForkAndEnsureTargetBranchExistsFromDesiredBranch(any());
         assertEquals(repoMap.size(), 3);
     }
 
@@ -148,16 +148,16 @@ public class ParentTest {
         when(contentsWithImageIterator.hasNext()).thenReturn(true, true, true, false);
         when(contentsWithImageIterator.next()).thenReturn(content1, content2, content3, null);
         when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
-        when(dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(contentRepo1)).thenReturn(null); // repo1 is unforkable
-        when(dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(duplicateContentRepo1)).thenReturn(null); // repo1 is unforkable
-        when(dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(contentRepo2)).thenReturn(new GHRepository());
+        when(dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(contentRepo1)).thenReturn(null); // repo1 is unforkable
+        when(dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(duplicateContentRepo1)).thenReturn(null); // repo1 is unforkable
+        when(dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(contentRepo2)).thenReturn(new GHRepository());
 
         Parent parent = new Parent();
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
         Multimap<String, String> repoMap =  parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
 
         // Since repo "1" is unforkable, we will only try to update repo "2"
-        verify(dockerfileGitHubUtil, times(3)).closeOutdatedPullRequestAndFork(any());
+        verify(dockerfileGitHubUtil, times(3)).getForkAndEnsureTargetBranchExistsFromDesiredBranch(any());
         assertEquals(repoMap.size(), 1);
     }
 
@@ -183,7 +183,7 @@ public class ParentTest {
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
         Multimap<String, String> repoMap = parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
 
-        verify(dockerfileGitHubUtil, never()).closeOutdatedPullRequestAndFork(any());
+        verify(dockerfileGitHubUtil, never()).getForkAndEnsureTargetBranchExistsFromDesiredBranch(any());
         assertEquals(repoMap.size(), 0);
     }
 
@@ -422,7 +422,7 @@ public class ParentTest {
         parent.loadDockerfileGithubUtil(dockerfileGitHubUtil);
         Multimap<String, String> pathToDockerfiles = parent.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage);
         assertTrue(pathToDockerfiles.isEmpty());
-        Mockito.verify(dockerfileGitHubUtil, times(0)).closeOutdatedPullRequestAndFork(any());
+        Mockito.verify(dockerfileGitHubUtil, times(0)).getForkAndEnsureTargetBranchExistsFromDesiredBranch(any());
     }
 
     @Test

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -10,6 +10,7 @@ package com.salesforce.dockerfileimageupdate.utils;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import com.salesforce.dockerfileimageupdate.model.GitForkBranch;
 import org.kohsuke.github.*;
 import org.mockito.Mock;
 import org.testng.annotations.DataProvider;
@@ -20,10 +21,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 
@@ -44,7 +44,7 @@ public class DockerfileGitHubUtilTest {
     }
 
     @Test
-    public void testExistingPullRequestClosedAndParentIsForkedOnlyOnce() throws Exception {
+    public void testParentIsForkedOnlyOnce() throws Exception {
         gitHubUtil = mock(GitHubUtil.class);
 
         GHRepository parent = mock(GHRepository.class);
@@ -68,77 +68,7 @@ public class DockerfileGitHubUtilTest {
         when(parent.listForks()).thenReturn(listOfForks);
 
         dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
-        GHPullRequest ghPullRequest = mockPullRequestAlreadyExists_True(parent, myself);
-        GHRepository returnRepo = dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(parent);
-        verify(ghPullRequest, times(1)).close();
-        verify(gitHubUtil, times(1)).createFork(parent);
-        assertNotNull(returnRepo);
-    }
-
-    @Test
-    public void testParentIsForked_whenNoPullRequestExists() throws Exception {
-        gitHubUtil = mock(GitHubUtil.class);
-
-        GHRepository parent = mock(GHRepository.class);
-        GHRepository fork = mock(GHRepository.class);
-        when(fork.getOwnerName()).thenReturn("me");
-
-        doCallRealMethod().when(gitHubUtil).safeDeleteRepo(fork);
-
-        GHMyself myself = mock(GHMyself.class);
-        when(myself.getLogin()).thenReturn("me");
-
-        PagedIterable<GHRepository> listOfForks = mock(PagedIterable.class);
-        PagedIterator<GHRepository> listOfForksIterator = mock(PagedIterator.class);
-
-        when(gitHubUtil.createFork(parent)).thenReturn(new GHRepository());
-        when(gitHubUtil.getMyself()).thenReturn(myself);
-
-        when(listOfForksIterator.next()).thenReturn(fork);
-        when(listOfForksIterator.hasNext()).thenReturn(true, false);
-        when(listOfForks.iterator()).thenReturn(listOfForksIterator);
-        when(parent.listForks()).thenReturn(listOfForks);
-
-        dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
-        GHPullRequest ghPullRequest = mockPullRequestAlreadyExists_False(parent, myself);
-        GHRepository returnRepo = dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(parent);
-        // No PR exists hence PullRequest.close() is not called
-        verify(ghPullRequest, times(0)).close();
-        verify(gitHubUtil, times(1)).createFork(parent);
-        verify(fork, times(1)).delete();
-        assertNotNull(returnRepo);
-    }
-
-    @Test
-    public void testParentIsForked_whenPullRequestFetchThrowsIOException() throws
-            Exception {
-        gitHubUtil = mock(GitHubUtil.class);
-
-        GHRepository parent = mock(GHRepository.class);
-        GHRepository fork = mock(GHRepository.class);
-        when(fork.getOwnerName()).thenReturn("me");
-
-        doCallRealMethod().when(gitHubUtil).safeDeleteRepo(fork);
-
-        GHMyself myself = mock(GHMyself.class);
-        when(myself.getLogin()).thenReturn("me");
-
-        PagedIterable<GHRepository> listOfForks = mock(PagedIterable.class);
-        PagedIterator<GHRepository> listOfForksIterator = mock(PagedIterator.class);
-
-        when(gitHubUtil.createFork(parent)).thenReturn(new GHRepository());
-        when(gitHubUtil.getMyself()).thenReturn(myself);
-
-        when(listOfForksIterator.next()).thenReturn(fork);
-        when(listOfForksIterator.hasNext()).thenReturn(true, false);
-        when(listOfForks.iterator()).thenReturn(listOfForksIterator);
-        when(parent.listForks()).thenReturn(listOfForks);
-
-        dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
-        mockPullRequestAlreadyExists_Error(parent);
-        GHRepository returnRepo = dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(parent);
-        verify(gitHubUtil, times(1)).createFork(parent);
-        verify(fork, times(1)).delete();
+        GHRepository returnRepo = dockerfileGitHubUtil.getOrCreateFork(parent);
         assertNotNull(returnRepo);
     }
 
@@ -167,28 +97,55 @@ public class DockerfileGitHubUtilTest {
         when(parent.listForks()).thenReturn(listOfForks);
 
         dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
-        GHRepository returnRepo = dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(parent);
+        GHRepository returnRepo = dockerfileGitHubUtil.getOrCreateFork(parent);
         assertNull(returnRepo);
     }
 
-    private GHPullRequest mockPullRequestAlreadyExists_True(GHRepository parent, GHMyself myself) throws IOException {
-        List<GHPullRequest> pullRequests = mock(List.class);
-        Iterator<GHPullRequest> pullRequestIterator = mock(Iterator.class);
-
-
+    @Test
+    public void testReturnPullRequestForBranch() {
+        String imageName = "someimage";
         GHPullRequest ghPullRequest = mock(GHPullRequest.class);
-        when(ghPullRequest.getBody()).thenReturn(Constants.PULL_REQ_ID);
-        GHCommitPointer head = mock(GHCommitPointer.class);
+        GHPullRequestQueryBuilder queryBuilder = getGHPullRequestQueryBuilder(imageName, Optional.of(ghPullRequest));
+        GHRepository parent = mock(GHRepository.class);
+        when(parent.queryPullRequests()).thenReturn(queryBuilder);
+        GitForkBranch gitForkBranch = new GitForkBranch(imageName, "", null);
 
-        when(head.getUser()).thenReturn(myself);
-        when(ghPullRequest.getHead()).thenReturn(head);
 
-        when(pullRequestIterator.next()).thenReturn(ghPullRequest);
-        when(pullRequestIterator.hasNext()).thenReturn(true);
+        gitHubUtil = mock(GitHubUtil.class);
+        dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
+        assertEquals(dockerfileGitHubUtil.getPullRequestForImageBranch(parent, gitForkBranch), Optional.of(ghPullRequest));
+    }
+
+    @Test
+    public void testNoPullRequestForBranch() {
+        String imageName = "someimage";
+        GHPullRequest ghPullRequest = mock(GHPullRequest.class);
+        GHPullRequestQueryBuilder queryBuilder = getGHPullRequestQueryBuilder(imageName, Optional.empty());
+        GHRepository parent = mock(GHRepository.class);
+        when(parent.queryPullRequests()).thenReturn(queryBuilder);
+        GitForkBranch gitForkBranch = new GitForkBranch(imageName, "", null);
+
+
+        gitHubUtil = mock(GitHubUtil.class);
+        dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
+        assertEquals(dockerfileGitHubUtil.getPullRequestForImageBranch(parent, gitForkBranch), Optional.empty());
+    }
+
+    private GHPullRequestQueryBuilder getGHPullRequestQueryBuilder(String imageName, Optional<GHPullRequest> ghPullRequest) {
+        GHPullRequestQueryBuilder queryBuilder = mock(GHPullRequestQueryBuilder.class);
+        when(queryBuilder.state(GHIssueState.OPEN)).thenReturn(queryBuilder);
+        when(queryBuilder.head(imageName)).thenReturn(queryBuilder);
+        PagedIterable<GHPullRequest> pullRequests = mock(PagedIterable.class);
+        PagedIterator<GHPullRequest> pullRequestIterator = mock(PagedIterator.class);
+        if (ghPullRequest.isPresent()) {
+            when(pullRequestIterator.next()).thenReturn(ghPullRequest.get());
+            when(pullRequestIterator.hasNext()).thenReturn(true);
+        } else {
+            when(pullRequestIterator.hasNext()).thenReturn(false);
+        }
         when(pullRequests.iterator()).thenReturn(pullRequestIterator);
-
-        when(parent.getPullRequests(GHIssueState.OPEN)).thenReturn(pullRequests);
-        return ghPullRequest;
+        when(queryBuilder.list()).thenReturn(pullRequests);
+        return queryBuilder;
     }
 
     private GHPullRequest mockPullRequestAlreadyExists_False(GHRepository parent, GHMyself myself) throws IOException {
@@ -617,6 +574,14 @@ public class DockerfileGitHubUtilTest {
         gitHubUtil = mock(GitHubUtil.class);
 
         GHRepository forkRepo = mock(GHRepository.class);
+        GHPullRequestQueryBuilder prBuilder = mock(GHPullRequestQueryBuilder.class);
+        when(prBuilder.state(GHIssueState.OPEN)).thenReturn(prBuilder);
+        PagedIterable<GHPullRequest> iteratable = mock(PagedIterable.class);
+        when(prBuilder.list()).thenReturn(iteratable);
+        PagedIterator<GHPullRequest> iterator = mock(PagedIterator.class);
+        when(iterator.hasNext()).thenReturn(false);
+        when(iteratable.iterator()).thenReturn(iterator);
+        when(forkRepo.queryPullRequests()).thenReturn(prBuilder);
         when(gitHubUtil.createPullReq(any(), anyString(), any(), anyString(), eq(Constants.PULL_REQ_ID))).thenReturn(1);
         doCallRealMethod().when(gitHubUtil).safeDeleteRepo(forkRepo);
         dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -11,6 +11,7 @@ package com.salesforce.dockerfileimageupdate.utils;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.salesforce.dockerfileimageupdate.model.GitForkBranch;
+import com.salesforce.dockerfileimageupdate.storage.GitHubJsonStore;
 import org.kohsuke.github.*;
 import org.mockito.Mock;
 import org.testng.annotations.DataProvider;
@@ -476,87 +477,6 @@ public class DockerfileGitHubUtilTest {
         dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(img, tag, stringBuilder, "world");
         dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(img, tag, stringBuilder, "this is a test");
         assertEquals(stringBuilder.toString(), "hello\nFROM image:7357\nworld\nthis is a test\n");
-    }
-
-    @DataProvider
-    public Object[][] inputStores() throws Exception {
-        return new Object[][] {
-                {"{\n  \"images\": {\n" +
-                        "    \"test\": \"testingtest\",\n" +
-                        "    \"asdfjkl\": \"asdfjkl\",\n" +
-                        "    \"7fce8488-31f4-4137-ad68-c19c3b33eebb\": \"manualtest\"\n" +
-                        "  }\n" +
-                        "}",
-                        "test", "newtag",
-                        "{\n  \"images\": {\n" +
-                                "    \"test\": \"newtag\",\n" +
-                                "    \"asdfjkl\": \"asdfjkl\",\n" +
-                                "    \"7fce8488-31f4-4137-ad68-c19c3b33eebb\": \"manualtest\"\n" +
-                                "  }\n" +
-                                "}"},
-                {"{\n  \"images\": {\n" +
-                        "    \"test\": \"testingtest\",\n" +
-                        "    \"asdfjkl\": \"asdfjkl\",\n" +
-                        "    \"7fce8488-31f4-4137-ad68-c19c3b33eebb\": \"manualtest\"\n" +
-                        "  }\n" +
-                        "}",
-                        "test", "test",
-                        "{\n  \"images\": {\n" +
-                                "    \"test\": \"test\",\n" +
-                                "    \"asdfjkl\": \"asdfjkl\",\n" +
-                                "    \"7fce8488-31f4-4137-ad68-c19c3b33eebb\": \"manualtest\"\n" +
-                                "  }\n" +
-                                "}"},
-                {"{\n  \"images\": {\n" +
-                        "    \"test\": \"testingtest\",\n" +
-                        "    \"asdfjkl\": \"asdfjkl\",\n" +
-                        "    \"7fce8488-31f4-4137-ad68-c19c3b33eebb\": \"manualtest\"\n" +
-                        "  }\n" +
-                        "}",
-                        "newImage", "newtag2",
-                        "{\n  \"images\": {\n" +
-                                "    \"test\": \"testingtest\",\n" +
-                                "    \"asdfjkl\": \"asdfjkl\",\n" +
-                                "    \"7fce8488-31f4-4137-ad68-c19c3b33eebb\": \"manualtest\",\n" +
-                                "    \"newImage\": \"newtag2\"\n" +
-                                "  }\n" +
-                                "}"},
-                {"{}", "image", "tag",
-                        "{\n  \"images\": {\n" +
-                                "    \"image\": \"tag\"\n" +
-                                "  }\n" +
-                                "}"},
-                {"{}", "test", "test",
-                        "{\n  \"images\": {\n" +
-                                "    \"test\": \"test\"\n" +
-                                "  }\n" +
-                                "}"},
-                {"", "image", "tag",
-                        "{\n  \"images\": {\n" +
-                                "    \"image\": \"tag\"\n" +
-                                "  }\n" +
-                                "}"},
-                {"{\n  \"images\": {\n" +
-                        "  }\n" +
-                        "}",
-                        "image", "tag",
-                        "{\n  \"images\": {\n" +
-                                "    \"image\": \"tag\"\n" +
-                                "  }\n" +
-                                "}"}
-
-        };
-    }
-
-    @Test(dataProvider = "inputStores")
-    public void testGetAndModifyJsonString(String storeContent, String image, String tag, String expectedOutput) throws Exception {
-        gitHubUtil = mock(GitHubUtil.class);
-
-        JsonElement json = new JsonParser().parse(storeContent);
-
-        dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
-        String output = dockerfileGitHubUtil.getAndModifyJsonString(json, image, tag);
-        assertEquals(output, expectedOutput);
     }
 
     @Test

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -589,5 +589,38 @@ public class DockerfileGitHubUtilTest {
         verify(gitHubUtil, times(1)).createPullReq(any(), anyString(), any(), anyString(), eq(Constants.PULL_REQ_ID));
         verify(forkRepo, times(1)).delete();
     }
+    @Test
+    public void testGetGHContents() throws Exception {
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
 
+        GHContent content1 = mock(GHContent.class);
+        GHContent content2 = mock(GHContent.class);
+        GHContent content3 = mock(GHContent.class);
+
+        PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
+        when(contentsWithImage.getTotalCount()).thenReturn(3);
+
+        PagedIterator<GHContent> contentsWithImageIterator = mock(PagedIterator.class);
+        when(contentsWithImageIterator.hasNext()).thenReturn(true, true, true, false);
+        when(contentsWithImageIterator.next()).thenReturn(content1, content2, content3, null);
+        when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
+
+        when(dockerfileGitHubUtil.findFilesWithImage(anyString(), eq("org"))).thenReturn(contentsWithImage);
+        when(dockerfileGitHubUtil.getGHContents("org", "image")).thenCallRealMethod();
+
+        assertEquals(dockerfileGitHubUtil.getGHContents("org", "image"), Optional.of(contentsWithImage));
+    }
+
+    @Test
+    public void testGHContentsNoOutput() throws Exception {
+
+        PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
+        when(contentsWithImage.getTotalCount()).thenReturn(0);
+
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        when(dockerfileGitHubUtil.findFilesWithImage(anyString(), eq("org"))).thenReturn(contentsWithImage);
+        when(dockerfileGitHubUtil.getGHContents("org", "image")).thenCallRealMethod();
+
+        assertEquals(dockerfileGitHubUtil.getGHContents("org", "image"), Optional.empty());
+    }
 }

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -69,7 +69,7 @@ public class DockerfileGitHubUtilTest {
 
         dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
         GHPullRequest ghPullRequest = mockPullRequestAlreadyExists_True(parent, myself);
-        GHRepository returnRepo = dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(parent);
+        GHRepository returnRepo = dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(parent);
         verify(ghPullRequest, times(1)).close();
         verify(gitHubUtil, times(1)).createFork(parent);
         assertNotNull(returnRepo);
@@ -101,7 +101,7 @@ public class DockerfileGitHubUtilTest {
 
         dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
         GHPullRequest ghPullRequest = mockPullRequestAlreadyExists_False(parent, myself);
-        GHRepository returnRepo = dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(parent);
+        GHRepository returnRepo = dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(parent);
         // No PR exists hence PullRequest.close() is not called
         verify(ghPullRequest, times(0)).close();
         verify(gitHubUtil, times(1)).createFork(parent);
@@ -136,7 +136,7 @@ public class DockerfileGitHubUtilTest {
 
         dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
         mockPullRequestAlreadyExists_Error(parent);
-        GHRepository returnRepo = dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(parent);
+        GHRepository returnRepo = dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(parent);
         verify(gitHubUtil, times(1)).createFork(parent);
         verify(fork, times(1)).delete();
         assertNotNull(returnRepo);
@@ -167,7 +167,7 @@ public class DockerfileGitHubUtilTest {
         when(parent.listForks()).thenReturn(listOfForks);
 
         dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
-        GHRepository returnRepo = dockerfileGitHubUtil.closeOutdatedPullRequestAndFork(parent);
+        GHRepository returnRepo = dockerfileGitHubUtil.getForkAndEnsureTargetBranchExistsFromDesiredBranch(parent);
         assertNull(returnRepo);
     }
 

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -8,10 +8,7 @@
 
 package com.salesforce.dockerfileimageupdate.utils;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
 import com.salesforce.dockerfileimageupdate.model.GitForkBranch;
-import com.salesforce.dockerfileimageupdate.storage.GitHubJsonStore;
 import org.kohsuke.github.*;
 import org.mockito.Mock;
 import org.testng.annotations.DataProvider;

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtilTest.java
@@ -85,6 +85,7 @@ public class GitHubUtilTest {
         GitHubUtil gitHubUtil = new GitHubUtil(github);
         GHRepository origRepo = mock(GHRepository.class);
         when(origRepo.getDefaultBranch()).thenReturn("master");
+        when(origRepo.createPullRequest(any(), any(), any(), any())).thenReturn(mock(GHPullRequest.class));
         GHRepository forkRepo = mock(GHRepository.class);
         when(forkRepo.getOwnerName()).thenReturn("owner");
         assertEquals(gitHubUtil.createPullReq(origRepo, "branch", forkRepo, "title", "body"), 0);

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/ResultsProcessorTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/ResultsProcessorTest.java
@@ -1,0 +1,38 @@
+package com.salesforce.dockerfileimageupdate.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static com.salesforce.dockerfileimageupdate.utils.ResultsProcessor.REPOS_SKIPPED_MESSAGE;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.fail;
+
+public class ResultsProcessorTest {
+
+    @Test(expectedExceptions = IOException.class)
+    public void testProcessResultsHasExceptionsAndThrows() throws IOException {
+        ResultsProcessor.processResults(new ArrayList<>(),
+                Collections.singletonList(new IOException("test")),
+                LoggerFactory.getLogger(ResultsProcessorTest.class));
+    }
+
+    @Test
+    public void testProcessResultsHasSkippedReposAndExceptions() {
+        Logger mockLogger = mock(Logger.class);
+        List<String> skippedRepos = Collections.singletonList("skipped");
+        try {
+            ResultsProcessor.processResults(skippedRepos,
+                    Collections.singletonList(new IOException("test")),
+                    mockLogger);
+            fail();
+        } catch (IOException exception) {
+            verify(mockLogger, times(1)).info(REPOS_SKIPPED_MESSAGE, skippedRepos);
+        }
+    }
+}

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/ResultsProcessorTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/ResultsProcessorTest.java
@@ -35,4 +35,13 @@ public class ResultsProcessorTest {
             verify(mockLogger, times(1)).info(REPOS_SKIPPED_MESSAGE, skippedRepos);
         }
     }
+
+    @Test
+    public void testProcessResultsHasNothingToReport() throws IOException {
+        Logger mockLogger = mock(Logger.class);
+        ResultsProcessor.processResults(new ArrayList<>(),
+                new ArrayList<>(),
+                mockLogger);
+        verify(mockLogger, times(0)).info(any(), anyList());
+    }
 }


### PR DESCRIPTION
It has proven wasteful and confusing to remove forks.

This changes the `parent` and `child` commands to use branches with a name based on the new `image-tag` combination.

This will have the following benefits:
* Stop closing forks and creating new ones
  * This will keep PRs for other image-tag combos open
* Create a branch specific to the image-tag combo we're updating to (which provides more context for the PR)
  * A benefit here is that it is also easier to locate DFIU PRs without requiring the usage of a specific PR body ([PULL_REQ_ID](https://github.com/salesforce/dockerfile-image-update/blob/master/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java#L30) will no longer be necessary and we can provide more context in the PR body).

Parent and Child are covered by #72 - All will keep the current strategy.