### PR TITLE
Check if we will need to make a change to the primary repo's default branch before forking

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/FromInstruction.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/FromInstruction.java
@@ -92,6 +92,22 @@ public class FromInstruction {
     }
 
     /**
+     * Check if this {@code lineInFile} is a FROM instruction, it is referencing {@code imageName} as a base image,
+     * and the tag is not the same as {@code imageTag} (or there is no tag)
+     *
+     * @param lineInFile a single line from a file
+     * @param imageName the base image name we're looking for
+     * @param imageTag the proposed new tag
+     */
+    public static boolean isFromInstructionWithThisImageAndOlderTag(String lineInFile, String imageName, String imageTag) {
+        if (FromInstruction.isFromInstruction(lineInFile)) {
+            FromInstruction fromInstruction = new FromInstruction(lineInFile);
+            return fromInstruction.hasBaseImage(imageName) && fromInstruction.hasADifferentTag(imageTag);
+        }
+        return false;
+    }
+
+    /**
      * Get a new {@code FromInstruction} the same as this but with the {@code tag} set as {@code newTag}
      * @param newTag the new image tag
      * @return a new FROM with the new image tag

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/ShouldForkResult.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/ShouldForkResult.java
@@ -1,0 +1,70 @@
+package com.salesforce.dockerfileimageupdate.model;
+
+
+import com.google.common.base.Objects;
+
+/**
+ * A result which can help determine if a repo should be forked or not.
+ * If it should not be forked, comes with a reason.
+ */
+public class ShouldForkResult {
+    public static final String NO_REASON = "no reason. Repo can be forked.";
+    private final boolean shouldFork;
+    private final String reason;
+
+    private ShouldForkResult(boolean shouldFork, String reason) {
+        this.shouldFork = shouldFork;
+        this.reason = reason;
+    }
+
+    public static ShouldForkResult shouldForkResult() {
+        return new ShouldForkResult(true, NO_REASON);
+    }
+
+    public static ShouldForkResult shouldNotForkResult(String reason) {
+        return new ShouldForkResult(false, reason);
+    }
+
+    /**
+     * Allows for chaining ShouldForkResult instances such that and() will return the first
+     * ShouldForkResult which results in isForkable() == false.
+     *
+     * @param otherShouldForkResult the other ShouldForkResult to return if this is forkable.
+     */
+    public ShouldForkResult and(ShouldForkResult otherShouldForkResult) {
+        if (isForkable()) {
+            return otherShouldForkResult;
+        }
+        return this;
+    }
+
+    public boolean isForkable() {
+        return shouldFork;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ShouldForkResult that = (ShouldForkResult) o;
+        return shouldFork == that.shouldFork &&
+                Objects.equal(reason, that.reason);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(shouldFork, reason);
+    }
+
+    @Override
+    public String toString() {
+        if (isForkable()) {
+            return "ShouldForkResult[Is forkable]";
+        }
+        return String.format("ShouldForkResult[Not forkable because %s", getReason());
+    }
+}

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidator.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidator.java
@@ -97,12 +97,9 @@ public class ForkableRepoValidator {
              BufferedReader reader = new BufferedReader(streamR)) {
             String line;
             while ( (line = reader.readLine()) != null ) {
-                if (FromInstruction.isFromInstruction(line)) {
-                    FromInstruction fromInstruction = new FromInstruction(line);
-                    if (fromInstruction.hasBaseImage(gitForkBranch.getImageName()) &&
-                            fromInstruction.hasADifferentTag(gitForkBranch.getImageTag())) {
-                        return false;
-                    }
+                if (FromInstruction.isFromInstructionWithThisImageAndOlderTag(line,
+                        gitForkBranch.getImageName(), gitForkBranch.getImageTag())) {
+                    return false;
                 }
             }
         } catch (IOException exception) {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidator.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidator.java
@@ -1,0 +1,133 @@
+package com.salesforce.dockerfileimageupdate.process;
+
+import com.salesforce.dockerfileimageupdate.model.GitForkBranch;
+import com.salesforce.dockerfileimageupdate.model.ShouldForkResult;
+import com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil;
+import org.kohsuke.github.GHContent;
+import org.kohsuke.github.GHRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import static com.salesforce.dockerfileimageupdate.model.ShouldForkResult.shouldForkResult;
+import static com.salesforce.dockerfileimageupdate.model.ShouldForkResult.shouldNotForkResult;
+
+public class ForkableRepoValidator {
+    private static final Logger log = LoggerFactory.getLogger(ForkableRepoValidator.class);
+
+    public static final String REPO_IS_FORK =
+            "it's a fork already. Sending a PR to a fork is unsupported at the moment.";
+    public static final String REPO_IS_ARCHIVED = "it's archived.";
+    public static final String REPO_IS_OWNED_BY_THIS_USER = "it is owned by this user.";
+    public static final String COULD_NOT_CHECK_THIS_USER =
+            "we could not determine fork status because we don't know the identity of the authenticated user.";
+    public static final String CONTENT_PATH_NOT_IN_DEFAULT_BRANCH_TEMPLATE =
+            "didn't find content path %s in default branch";
+    public static final String COULD_NOT_FIND_IMAGE_TO_UPDATE_TEMPLATE =
+            "didn't find the image '%s' which required an update in path %s";
+    private final DockerfileGitHubUtil dockerfileGitHubUtil;
+
+    public ForkableRepoValidator(DockerfileGitHubUtil dockerfileGitHubUtil) {
+        this.dockerfileGitHubUtil = dockerfileGitHubUtil;
+    }
+
+    /**
+     * Check various conditions required for a repo to qualify for updates
+     *
+     * @param parentRepo parent repo we're checking
+     * @param searchResultContent search result content we'll check against
+     * @return should we fork the parentRepo?
+     */
+    public ShouldForkResult shouldFork(GHRepository parentRepo,
+                                       GHContent searchResultContent,
+                                       GitForkBranch gitForkBranch) {
+        return parentIsFork(parentRepo)
+                .and(parentIsArchived(parentRepo)
+                        .and(thisUserIsNotOwner(parentRepo)));
+//                                .and(contentExistsInDefaultBranch(parentRepo, searchResultContent, gitForkBranch))));
+    }
+
+//    protected ShouldForkResult contentExistsInDefaultBranch(GHRepository parentRepo,
+//                                                            GHContent searchResultContent,
+//                                                            GitForkBranch gitForkBranch) {
+//        try {
+//            String searchContentPath = searchResultContent.getPath();
+//            GHContent content =
+//                    dockerfileGitHubUtil.tryRetrievingContent(parentRepo,
+//                            searchContentPath, parentRepo.getDefaultBranch());
+//            if (content == null) {
+//                return shouldNotForkResult(
+//                        String.format(CONTENT_PATH_NOT_IN_DEFAULT_BRANCH_TEMPLATE, searchContentPath));
+//            } else {
+//                // TODO: check to see if it's got our FROM
+//                if (!needsToBeUpdated(content, gitForkBranch)) {
+//                    return shouldNotForkResult(
+//                            String.format(COULD_NOT_FIND_IMAGE_TO_UPDATE_TEMPLATE,
+//                                    gitForkBranch.getImageName(), searchContentPath));
+//                }
+//            }
+//        } catch (InterruptedException e) {
+//            log.warn("Couldn't get parent content to check for some reason. Trying to proceed...");
+//        }
+//        return shouldForkResult();
+//    }
+//
+//    protected boolean needsToBeUpdated(GHContent content, GitForkBranch gitForkBranch) {
+//        try (InputStream stream = content.read();
+//             InputStreamReader streamR = new InputStreamReader(stream);
+//             BufferedReader reader = new BufferedReader(streamR)) {
+//            String line;
+//            while ( (line = reader.readLine()) != null ) {
+//                if (FromInstruction.isFromInstruction(line)) {
+//                    FromInstruction fromInstruction = new FromInstruction(line);
+//                    if (fromInstruction.hasBaseImage(gitForkBranch.getImageName()) &&
+//                            fromInstruction.hasADifferentTag(gitForkBranch.getImageTag())) {
+//                        return true;
+//                    }
+//                }
+//            }
+//
+//        } catch (IOException exception) {
+//            exception.printStackTrace();
+//        }
+//        return false;
+//    }
+//
+    /**
+     * Attempts to check to see if this user is the owner of the repo (don't fork your own repo).
+     * If we can't tell because of a systemic error, don't attempt to fork (we could perhaps loosen this in the future).
+     * If this user is the owner of the repo, do not fork.
+     *
+     * @param parentRepo parent repo we're checking
+     */
+    protected ShouldForkResult thisUserIsNotOwner(GHRepository parentRepo) {
+        try {
+            if (dockerfileGitHubUtil.thisUserIsOwner(parentRepo)) {
+                return shouldNotForkResult(REPO_IS_OWNED_BY_THIS_USER);
+            }
+        } catch (IOException ioException) {
+            return shouldNotForkResult(COULD_NOT_CHECK_THIS_USER);
+        }
+        return shouldForkResult();
+    }
+
+    /**
+     * Check if parentRepo is a fork. Do not fork a fork (for now, at least).
+     *
+     * @param parentRepo parent repo we're checking
+     */
+    protected ShouldForkResult parentIsFork(GHRepository parentRepo) {
+        return parentRepo.isFork() ? shouldNotForkResult(REPO_IS_FORK) : shouldForkResult();
+    }
+
+    /**
+     * Check if parentRepo is archived. We won't be able to update it, so do not fork.
+     *
+     * @param parentRepo parent repo we're checking
+     */
+    protected ShouldForkResult parentIsArchived(GHRepository parentRepo) {
+        return parentRepo.isArchived() ? shouldNotForkResult(REPO_IS_ARCHIVED) : shouldForkResult();
+
+    }
+}

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Multimap;
 import com.salesforce.dockerfileimageupdate.SubCommand;
 import com.salesforce.dockerfileimageupdate.model.GitForkBranch;
 import com.salesforce.dockerfileimageupdate.model.GitHubContentToProcess;
+import com.salesforce.dockerfileimageupdate.process.ForkableRepoValidator;
 import com.salesforce.dockerfileimageupdate.process.GitHubPullRequestSender;
 import com.salesforce.dockerfileimageupdate.subcommands.ExecutableWithNamespace;
 import com.salesforce.dockerfileimageupdate.utils.Constants;
@@ -48,7 +49,8 @@ public class Parent implements ExecutableWithNamespace {
         log.info("Updating store...");
         this.dockerfileGitHubUtil.getGitHubJsonStore(ns.get(Constants.STORE)).updateStore(img, tag);
 
-        GitHubPullRequestSender pullRequestSender = new GitHubPullRequestSender(dockerfileGitHubUtil);
+        GitHubPullRequestSender pullRequestSender =
+                new GitHubPullRequestSender(dockerfileGitHubUtil, new ForkableRepoValidator(dockerfileGitHubUtil));
 
         GitForkBranch gitForkBranch =
                 new GitForkBranch(ns.get(Constants.IMG), ns.get(Constants.TAG), ns.get(Constants.GIT_BRANCH));

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
@@ -50,10 +50,14 @@ public class Parent implements ExecutableWithNamespace {
 
         GitHubPullRequestSender pullRequestSender = new GitHubPullRequestSender(dockerfileGitHubUtil);
 
+        GitForkBranch gitForkBranch =
+                new GitForkBranch(ns.get(Constants.IMG), ns.get(Constants.TAG), ns.get(Constants.GIT_BRANCH));
+
         log.info("Finding Dockerfiles with the given image...");
         Optional<PagedSearchIterable<GHContent>> contentsWithImage = dockerfileGitHubUtil.getGHContents(ns.get(Constants.GIT_ORG), img);
         if (contentsWithImage.isPresent()) {
-            Multimap<String, GitHubContentToProcess> pathToDockerfilesInParentRepo = pullRequestSender.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage.get());
+            Multimap<String, GitHubContentToProcess> pathToDockerfilesInParentRepo =
+                    pullRequestSender.forkRepositoriesFoundAndGetPathToDockerfiles(contentsWithImage.get(), gitForkBranch);
             List<IOException> exceptions = new ArrayList<>();
             List<String> skippedRepos = new ArrayList<>();
 

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/FromInstructionTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/FromInstructionTest.java
@@ -224,4 +224,19 @@ public class FromInstructionTest {
     public void testInvalidFromData(String input) {
         new FromInstruction(input);
     }
+
+    @DataProvider
+    public Object[][] isFromInstructionWithThisImageAndOlderTagData() {
+        return new Object[][]{
+                {"FROM someimage", "someimage", "sometag", true},
+                {"FROM someimage:sometag", "someimage", "sometag", false},
+                {"not a from instruction", "someimage", "sometag", false},
+                {"FROM someimage", "someimage", "sometag", true}
+        };
+    }
+
+    @Test(dataProvider = "isFromInstructionWithThisImageAndOlderTagData")
+    public void isFromInstructionWithThisImageAndOlderTag(String line, String imageName, String imageTag, boolean expectedResult) {
+        assertEquals(FromInstruction.isFromInstructionWithThisImageAndOlderTag(line, imageName, imageTag), expectedResult);
+    }
 }

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/ShouldForkResultTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/ShouldForkResultTest.java
@@ -1,0 +1,82 @@
+package com.salesforce.dockerfileimageupdate.model;
+
+import com.salesforce.dockerfileimageupdate.process.ForkableRepoValidator;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static com.salesforce.dockerfileimageupdate.model.ShouldForkResult.*;
+import static com.salesforce.dockerfileimageupdate.process.ForkableRepoValidator.REPO_IS_ARCHIVED;
+import static org.testng.Assert.*;
+
+public class ShouldForkResultTest {
+    @Test
+    public void testShouldForkResult() {
+        ShouldForkResult shouldForkResult = shouldForkResult();
+        assertTrue(shouldForkResult.isForkable());
+        assertEquals(shouldForkResult.getReason(), NO_REASON);
+    }
+
+    @DataProvider
+    public Object[][] testEqualsData() {
+        ShouldForkResult same = shouldForkResult();
+        return new Object[][]{
+                {same, same},
+                {shouldForkResult(), shouldForkResult()},
+                {shouldNotForkResult("test"), shouldNotForkResult("test")},
+                {shouldNotForkResult(REPO_IS_ARCHIVED), shouldNotForkResult(REPO_IS_ARCHIVED)},
+        };
+    }
+
+    @Test(dataProvider = "testEqualsData")
+    public void testEquals(ShouldForkResult first, ShouldForkResult second) {
+        assertEquals(first, second);
+    }
+
+    @Test
+    public void testNotEqual() {
+        assertNotEquals(shouldNotForkResult("another"), shouldNotForkResult("test"));
+    }
+
+    @Test
+    public void testEqualHashCode() {
+        assertEquals(shouldNotForkResult("test").hashCode(), shouldNotForkResult("test").hashCode());
+    }
+
+    @Test
+    public void testNotEqualHashCode() {
+        assertNotEquals(shouldNotForkResult("another").hashCode(), shouldNotForkResult("test").hashCode());
+    }
+
+    @DataProvider
+    public Object[][] shouldNotForkReasons() {
+        return new Object[][]{
+                {ForkableRepoValidator.COULD_NOT_CHECK_THIS_USER},
+                {ForkableRepoValidator.REPO_IS_FORK},
+                {REPO_IS_ARCHIVED},
+                {ForkableRepoValidator.REPO_IS_OWNED_BY_THIS_USER}
+        };
+    }
+
+    @Test(dataProvider = "shouldNotForkReasons")
+    public void testShouldNotForkResult(String reason) {
+        ShouldForkResult shouldForkResult = shouldNotForkResult(reason);
+        assertFalse(shouldForkResult.isForkable());
+        assertEquals(shouldForkResult.getReason(), reason);
+    }
+
+    @DataProvider
+    public Object[][] test2Ands() {
+        return new Object[][]{
+                {shouldForkResult(), shouldForkResult(), true, NO_REASON},
+                {shouldForkResult(), shouldNotForkResult(REPO_IS_ARCHIVED), false, REPO_IS_ARCHIVED},
+                {shouldNotForkResult(REPO_IS_ARCHIVED), shouldForkResult(), false, REPO_IS_ARCHIVED},
+                {shouldNotForkResult(REPO_IS_ARCHIVED), shouldNotForkResult(ForkableRepoValidator.REPO_IS_FORK), false, REPO_IS_ARCHIVED},
+        };
+    }
+
+    @Test(dataProvider = "test2Ands")
+    public void testAnd(ShouldForkResult shouldForkResult, ShouldForkResult shouldForkResult2, boolean result, String reason) {
+        assertEquals(shouldForkResult.and(shouldForkResult2).isForkable(), result);
+        assertEquals(shouldForkResult.and(shouldForkResult2).getReason(), reason);
+    }
+}

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidatorTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidatorTest.java
@@ -8,13 +8,16 @@ import org.kohsuke.github.GHRepository;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 import static com.salesforce.dockerfileimageupdate.model.ShouldForkResult.shouldForkResult;
 import static com.salesforce.dockerfileimageupdate.model.ShouldForkResult.shouldNotForkResult;
 import static com.salesforce.dockerfileimageupdate.process.ForkableRepoValidator.*;
 import static com.salesforce.dockerfileimageupdate.process.GitHubPullRequestSender.REPO_IS_FORK;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
@@ -26,12 +29,14 @@ public class ForkableRepoValidatorTest {
         ShouldForkResult dontForkBecauseFork = shouldNotForkResult(REPO_IS_FORK);
         ShouldForkResult dontForkBecauseArchive = shouldNotForkResult(REPO_IS_ARCHIVED);
         ShouldForkResult dontForkBecauseOwner = shouldNotForkResult(REPO_IS_OWNED_BY_THIS_USER);
+        ShouldForkResult dontForkNoContentChange = shouldNotForkResult("stub no content change message");
         return new Object[][]{
-                {shouldForkResult(), shouldForkResult(), shouldForkResult(), shouldForkResult()},
-                {dontForkBecauseFork, shouldForkResult(), shouldForkResult(), dontForkBecauseFork},
-                {dontForkBecauseFork, dontForkBecauseArchive, dontForkBecauseOwner, dontForkBecauseFork},
-                {shouldForkResult(), dontForkBecauseArchive, dontForkBecauseOwner, dontForkBecauseArchive},
-                {shouldForkResult(), shouldForkResult(), dontForkBecauseOwner, dontForkBecauseOwner},
+                {shouldForkResult(), shouldForkResult(), shouldForkResult(), shouldForkResult(), shouldForkResult()},
+                {dontForkBecauseFork, shouldForkResult(), shouldForkResult(), shouldForkResult(), dontForkBecauseFork},
+                {dontForkBecauseFork, dontForkBecauseArchive, dontForkBecauseOwner, shouldForkResult(), dontForkBecauseFork},
+                {shouldForkResult(), dontForkBecauseArchive, dontForkBecauseOwner, shouldForkResult(), dontForkBecauseArchive},
+                {shouldForkResult(), shouldForkResult(), dontForkBecauseOwner, shouldForkResult(), dontForkBecauseOwner},
+                {shouldForkResult(), shouldForkResult(), shouldForkResult(), dontForkNoContentChange, dontForkNoContentChange},
         };
     }
 
@@ -39,12 +44,14 @@ public class ForkableRepoValidatorTest {
     public void testShouldFork(ShouldForkResult isForkResult,
                                ShouldForkResult isArchivedResult,
                                ShouldForkResult userIsNotOwnerResult,
+                               ShouldForkResult contentHasChangesResult,
                                ShouldForkResult expectedResult) {
         ForkableRepoValidator validator = mock(ForkableRepoValidator.class);
 
         when(validator.parentIsFork(any())).thenReturn(isForkResult);
         when(validator.parentIsArchived(any())).thenReturn(isArchivedResult);
         when(validator.thisUserIsNotOwner(any())).thenReturn(userIsNotOwnerResult);
+        when(validator.contentHasChangesInDefaultBranch(any(), any(), any())).thenReturn(contentHasChangesResult);
         when(validator.shouldFork(any(), any(), any())).thenCallRealMethod();
 
         assertEquals(validator.shouldFork(mock(GHRepository.class), mock(GHContent.class), mock(GitForkBranch.class)),
@@ -130,5 +137,106 @@ public class ForkableRepoValidatorTest {
         when(repo.isArchived()).thenReturn(false);
         ShouldForkResult shouldForkResult = validator.parentIsArchived(repo);
         assertTrue(shouldForkResult.isForkable());
+    }
+
+    @Test
+    public void testContentHasChangesInDefaultBranch() throws InterruptedException, IOException {
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        GHRepository repo = mock(GHRepository.class);
+        ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
+        GHContent content = mock(GHContent.class);
+        when(content.getPath()).thenReturn("/Dockerfile");
+        GitForkBranch gitForkBranch = new GitForkBranch("someImage", "someTag", null);
+        when(dockerfileGitHubUtil.tryRetrievingContent(eq(repo), any(), any())).thenReturn(content);
+        InputStream inputStream = new ByteArrayInputStream("FROM someImage".getBytes());
+        when(content.read()).thenReturn(inputStream);
+
+        assertEquals(validator.contentHasChangesInDefaultBranch(repo, content, gitForkBranch), shouldForkResult());
+    }
+
+    @Test
+    public void testInterruptedExceptionWhenRetrievingContentInDefaultBranch() throws InterruptedException {
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        GHRepository repo = mock(GHRepository.class);
+        ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
+        GHContent content = mock(GHContent.class);
+        when(content.getPath()).thenReturn("/Dockerfile");
+        GitForkBranch gitForkBranch = new GitForkBranch("someImage", "someTag", null);
+        when(dockerfileGitHubUtil.tryRetrievingContent(eq(repo), any(), any())).thenThrow(new InterruptedException("some exception"));
+
+        assertEquals(validator.contentHasChangesInDefaultBranch(repo, content, gitForkBranch), shouldForkResult());
+    }
+
+    @Test
+    public void testContentHasNoChangesInDefaultBranch() throws InterruptedException, IOException {
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        GHRepository repo = mock(GHRepository.class);
+        ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
+        GHContent content = mock(GHContent.class);
+        String searchContentPath = "/Dockerfile";
+        when(content.getPath()).thenReturn(searchContentPath);
+        String imageName = "someImage";
+        GitForkBranch gitForkBranch = new GitForkBranch(imageName, "someTag", null);
+        when(dockerfileGitHubUtil.tryRetrievingContent(eq(repo), any(), any())).thenReturn(content);
+        InputStream inputStream = new ByteArrayInputStream("nochanges".getBytes());
+        when(content.read()).thenReturn(inputStream);
+
+        assertEquals(validator.contentHasChangesInDefaultBranch(repo, content, gitForkBranch),
+                shouldNotForkResult(String.format(COULD_NOT_FIND_IMAGE_TO_UPDATE_TEMPLATE, imageName, searchContentPath)));
+    }
+
+    @Test
+    public void testCouldNotFindContentInDefaultBranch() throws InterruptedException {
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        GHRepository repo = mock(GHRepository.class);
+        ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
+        GHContent content = mock(GHContent.class);
+        String searchContentPath = "/Dockerfile";
+        when(content.getPath()).thenReturn(searchContentPath);
+        GitForkBranch gitForkBranch = new GitForkBranch("someImage", "someTag", null);
+        when(dockerfileGitHubUtil.tryRetrievingContent(eq(repo), any(), any())).thenReturn(null);
+        InputStream inputStream = new ByteArrayInputStream("FROM someImage".getBytes());
+
+        assertEquals(validator.contentHasChangesInDefaultBranch(repo, content, gitForkBranch),
+                shouldNotForkResult(String.format(CONTENT_PATH_NOT_IN_DEFAULT_BRANCH_TEMPLATE, searchContentPath)));
+    }
+
+    @DataProvider
+    public Object[][] hasNoChangesData() {
+        return new Object[][]{
+                {"something", "imageName", "tag", true},
+                {"FROM imageName", "imageName", "tag", false},
+                {"FROM imageName:tag", "imageName", "tag", true},
+                {"FROM imageName:anotherTag", "imageName", "tag", false},
+                {"FROM anotherImage:tag", "imageName", "tag", true},
+        };
+    }
+
+    @Test(dataProvider = "hasNoChangesData")
+    public void testHasNoChanges(String contentText, String imageName, String imageTag, boolean expectedResult) throws IOException {
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        GHRepository repo = mock(GHRepository.class);
+        ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
+        GHContent content = mock(GHContent.class);
+        InputStream inputStream = new ByteArrayInputStream(contentText.getBytes());
+        GitForkBranch gitForkBranch = new GitForkBranch(imageName, imageTag, null);
+
+        when(content.read()).thenReturn(inputStream);
+
+        when(repo.isArchived()).thenReturn(false);
+        assertEquals(validator.hasNoChanges(content, gitForkBranch), expectedResult);
+    }
+
+    @Test
+    public void testHasNoChangesIfExceptionThrownDuringRead() throws IOException {
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        GHRepository repo = mock(GHRepository.class);
+        ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
+        GHContent content = mock(GHContent.class);
+        GitForkBranch gitForkBranch = new GitForkBranch("name", "tag", null);
+
+        when(content.read()).thenThrow(new IOException("failed on IO"));
+
+        assertTrue(validator.hasNoChanges(content, gitForkBranch));
     }
 }

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidatorTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidatorTest.java
@@ -1,0 +1,134 @@
+package com.salesforce.dockerfileimageupdate.process;
+
+import com.salesforce.dockerfileimageupdate.model.GitForkBranch;
+import com.salesforce.dockerfileimageupdate.model.ShouldForkResult;
+import com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil;
+import org.kohsuke.github.GHContent;
+import org.kohsuke.github.GHRepository;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static com.salesforce.dockerfileimageupdate.model.ShouldForkResult.shouldForkResult;
+import static com.salesforce.dockerfileimageupdate.model.ShouldForkResult.shouldNotForkResult;
+import static com.salesforce.dockerfileimageupdate.process.ForkableRepoValidator.*;
+import static com.salesforce.dockerfileimageupdate.process.GitHubPullRequestSender.REPO_IS_FORK;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+
+public class ForkableRepoValidatorTest {
+
+    @DataProvider
+    public Object[][] shouldForkData() {
+        ShouldForkResult dontForkBecauseFork = shouldNotForkResult(REPO_IS_FORK);
+        ShouldForkResult dontForkBecauseArchive = shouldNotForkResult(REPO_IS_ARCHIVED);
+        ShouldForkResult dontForkBecauseOwner = shouldNotForkResult(REPO_IS_OWNED_BY_THIS_USER);
+        return new Object[][]{
+                {shouldForkResult(), shouldForkResult(), shouldForkResult(), shouldForkResult()},
+                {dontForkBecauseFork, shouldForkResult(), shouldForkResult(), dontForkBecauseFork},
+                {dontForkBecauseFork, dontForkBecauseArchive, dontForkBecauseOwner, dontForkBecauseFork},
+                {shouldForkResult(), dontForkBecauseArchive, dontForkBecauseOwner, dontForkBecauseArchive},
+                {shouldForkResult(), shouldForkResult(), dontForkBecauseOwner, dontForkBecauseOwner},
+        };
+    }
+
+    @Test(dataProvider = "shouldForkData")
+    public void testShouldFork(ShouldForkResult isForkResult,
+                               ShouldForkResult isArchivedResult,
+                               ShouldForkResult userIsNotOwnerResult,
+                               ShouldForkResult expectedResult) {
+        ForkableRepoValidator validator = mock(ForkableRepoValidator.class);
+
+        when(validator.parentIsFork(any())).thenReturn(isForkResult);
+        when(validator.parentIsArchived(any())).thenReturn(isArchivedResult);
+        when(validator.thisUserIsNotOwner(any())).thenReturn(userIsNotOwnerResult);
+        when(validator.shouldFork(any(), any(), any())).thenCallRealMethod();
+
+        assertEquals(validator.shouldFork(mock(GHRepository.class), mock(GHContent.class), mock(GitForkBranch.class)),
+                expectedResult);
+    }
+
+    @Test
+    public void testCantForkThisUserIsNotOwner() throws IOException {
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        GHRepository repo = mock(GHRepository.class);
+        ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
+
+        when(dockerfileGitHubUtil.thisUserIsOwner(repo)).thenReturn(true);
+        ShouldForkResult shouldForkResult = validator.thisUserIsNotOwner(repo);
+        assertFalse(shouldForkResult.isForkable());
+        assertEquals(shouldForkResult.getReason(), REPO_IS_OWNED_BY_THIS_USER);
+    }
+
+    @Test
+    public void testCantForkCouldNotTellIfThisUserIsOwner() throws IOException {
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        GHRepository repo = mock(GHRepository.class);
+        ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
+
+        when(dockerfileGitHubUtil.thisUserIsOwner(repo)).thenThrow(new IOException("sad times"));
+        ShouldForkResult shouldForkResult = validator.thisUserIsNotOwner(repo);
+        assertFalse(shouldForkResult.isForkable());
+        assertEquals(shouldForkResult.getReason(), COULD_NOT_CHECK_THIS_USER);
+    }
+
+    @Test
+    public void testCanForkThisUserIsNotOwner() throws IOException {
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        GHRepository repo = mock(GHRepository.class);
+        ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
+
+        when(dockerfileGitHubUtil.thisUserIsOwner(repo)).thenReturn(false);
+        ShouldForkResult shouldForkResult = validator.thisUserIsNotOwner(repo);
+        assertTrue(shouldForkResult.isForkable());
+    }
+
+    @Test
+    public void testParentIsForkDoNotForkIt() {
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        GHRepository repo = mock(GHRepository.class);
+        ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
+
+        when(repo.isFork()).thenReturn(true);
+        ShouldForkResult shouldForkResult = validator.parentIsFork(repo);
+        assertFalse(shouldForkResult.isForkable());
+        assertEquals(shouldForkResult.getReason(), REPO_IS_FORK);
+    }
+
+    @Test
+    public void testParentIsNotForkSoForkIt() {
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        GHRepository repo = mock(GHRepository.class);
+        ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
+
+        when(repo.isFork()).thenReturn(false);
+        ShouldForkResult shouldForkResult = validator.parentIsFork(repo);
+        assertTrue(shouldForkResult.isForkable());
+    }
+
+    @Test
+    public void testParentIsArchivedDoNotForkIt() {
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        GHRepository repo = mock(GHRepository.class);
+        ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
+
+        when(repo.isArchived()).thenReturn(true);
+        ShouldForkResult shouldForkResult = validator.parentIsArchived(repo);
+        assertFalse(shouldForkResult.isForkable());
+        assertEquals(shouldForkResult.getReason(), REPO_IS_ARCHIVED);
+    }
+
+    @Test
+    public void testParentIsNotArchivedSoForkIt() {
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        GHRepository repo = mock(GHRepository.class);
+        ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
+
+        when(repo.isArchived()).thenReturn(false);
+        ShouldForkResult shouldForkResult = validator.parentIsArchived(repo);
+        assertTrue(shouldForkResult.isForkable());
+    }
+}


### PR DESCRIPTION
Extract ForkableRepoValidator from GHPRSender
* Responsible for determining whether we should fork a parent repo
* Returns ShouldForkResult

Check contentHasChangesInDefaultBranch before fork
* this will reduce the amount of unnecessary forks where a change isn't
going to be reflected in the PR at all

Closes #153 