### PR TITLE
Additional wait on fork creation before creating branch

### DIFF
--- a/dockerfile-image-update/pom.xml
+++ b/dockerfile-image-update/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.112</version>
+            <version>1.114</version>
         </dependency>
     </dependencies>
 

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -114,7 +114,7 @@ public class DockerfileGitHubUtil {
                 break;
             } catch (FileNotFoundException e1) {
                 log.warn("Content in repository not created yet. Retrying connection to fork...");
-                Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+                getGitHubUtil().waitFor(TimeUnit.SECONDS.toMillis(1));
             }
         }
         for (GHContent con : tree) {
@@ -246,15 +246,50 @@ public class DockerfileGitHubUtil {
         return Optional.empty();
     }
 
-    public void createOrUpdateForkBranchToParentDefault(GHRepository parent, GHRepository fork, GitForkBranch gitForkBranch) throws IOException {
+    /**
+     * Create or update the desired {@code gitForkBranch} in {@code fork} based off of the {@code parent} repo's
+     * default branch to ensure that {@code gitForkBranch} is on the latest commit.
+     *
+     * @param parent parent repo to base from
+     * @param fork fork repo where we'll create or modify the {@code gitForkBranch}
+     * @param gitForkBranch desired branch to create or update based on the parent's default branch
+     */
+    public void createOrUpdateForkBranchToParentDefault(GHRepository parent, GHRepository fork, GitForkBranch gitForkBranch) throws IOException, InterruptedException {
         GHBranch parentBranch = parent.getBranch(parent.getDefaultBranch());
         String sha1 = parentBranch.getSHA1();
-        GHBranch forkBranch = fork.getBranches().get(gitForkBranch.getBranchName());
+        waitForExistingForkBranch(fork, parent.getDefaultBranch());
+        GHBranch forkBranch = fork.getBranch(gitForkBranch.getBranchName());
         String branchRefName = String.format("refs/heads/%s", gitForkBranch.getBranchName());
         if (forkBranch == null) {
             fork.createRef(branchRefName, sha1);
         } else {
             fork.getRef(branchRefName).updateTo(sha1, true);
+        }
+    }
+
+    /**
+     * You must have branches in a repo in order to create a ref per:
+     * https://developer.github.com/enterprise/2.19/v3/git/refs/#create-a-reference
+     *
+     * Generally, we can assume that a fork should have branches so if it does not have branches, we're still
+     * waiting for GitHub to finish replicating the tree behind the scenes.
+     *
+     * @param fork - ensure that this repo has branches and wait until it does
+     * @param branchToCheck - the branch to check
+     */
+    protected void waitForExistingForkBranch(GHRepository fork, String branchToCheck) throws InterruptedException {
+        for (int i = 0; i < 10; i++) {
+            try {
+                GHBranch branch = fork.getBranch(branchToCheck);
+                if (branch != null) {
+                    return;
+                }
+            } catch (IOException exception) {
+                // Keep waiting - generally a GHFileNotFoundException - this is expected rather than a null branch but
+                // we'll handle both scenarios as neither would indicate that the fork branch is ready
+            }
+            log.warn(String.format("Couldn't find default branch `%s` in fork `%s`. Waiting a second...", branchToCheck, fork.getName()));
+            gitHubUtil.waitFor(TimeUnit.SECONDS.toMillis(1));
         }
     }
 
@@ -289,7 +324,7 @@ public class DockerfileGitHubUtil {
             if (contentsWithImage.getTotalCount() > 0) {
                 break;
             } else {
-                Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+                getGitHubUtil().waitFor(TimeUnit.SECONDS.toMillis(1));
             }
         }
 

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java
@@ -116,7 +116,7 @@ public class GitHubUtil {
             } else {
                 // TODO: THIS WILL LOOP FOREVVEEEEEERRRR
                 log.warn("An error occurred in pull request: {} Trying again...", error);
-                Thread.sleep(3000);
+                waitFor(TimeUnit.SECONDS.toMillis(3));
                 return -1;
             }
         }
@@ -130,7 +130,7 @@ public class GitHubUtil {
                 break;
             } catch (IOException e1) {
                 log.warn("Repository not created yet. Retrying connection to repository...");
-                Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+                waitFor(TimeUnit.SECONDS.toMillis(1));
             }
         }
         return repo;
@@ -147,7 +147,7 @@ public class GitHubUtil {
                 break;
             } catch (IOException e1) {
                 log.warn("Content in repository not created yet. Retrying connection to fork...");
-                Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+                waitFor(TimeUnit.SECONDS.toMillis(1));
             }
         }
         return content;
@@ -184,10 +184,14 @@ public class GitHubUtil {
                 break;
             } else {
                 log.info("Waiting for GitHub API cache to clear...");
-                Thread.sleep(TimeUnit.MINUTES.toMillis(1));
+                waitFor(TimeUnit.MINUTES.toMillis(1));
             }
         }
         return listOfRepos;
+    }
+
+    protected void waitFor(long millis) throws InterruptedException {
+        Thread.sleep(millis);
     }
 
     /**

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -545,74 +545,9 @@ public class DockerfileGitHubUtilTest {
     }
 
     @Test
-    public void testWaitForExistingForkBranchWaits10SecondsForExceptions() throws IOException, InterruptedException {
-        GitHubUtil gitHubUtil = mock(GitHubUtil.class);
-        GHRepository fork = mock(GHRepository.class);
-        when(fork.getBranch(any())).thenThrow(new GHFileNotFoundException(),
-                new GHFileNotFoundException(),
-                new GHFileNotFoundException(),
-                new GHFileNotFoundException(),
-                new GHFileNotFoundException(),
-                new GHFileNotFoundException(),
-                new GHFileNotFoundException(),
-                new GHFileNotFoundException(),
-                new GHFileNotFoundException(),
-                new GHFileNotFoundException(),
-                new GHFileNotFoundException());
-        DockerfileGitHubUtil dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
-
-        dockerfileGitHubUtil.waitForExistingForkBranch(fork, "somebranch");
-        verify(gitHubUtil, times(10)).waitFor(TimeUnit.SECONDS.toMillis(1));
-    }
-
-    @Test
-    public void testWaitForExistingForkBranchReturnsAfterFound() throws IOException, InterruptedException {
-        GitHubUtil gitHubUtil = mock(GitHubUtil.class);
-        GHRepository fork = mock(GHRepository.class);
-        when(fork.getBranch(any())).thenReturn(null, mock(GHBranch.class));
-        DockerfileGitHubUtil dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
-
-        dockerfileGitHubUtil.waitForExistingForkBranch(fork, "somebranch");
-        verify(gitHubUtil, times(1)).waitFor(TimeUnit.SECONDS.toMillis(1));
-    }
-
-    @Test
-    public void testWaitForExistingForkBranchReturnsImmediately() throws IOException, InterruptedException {
-        GitHubUtil gitHubUtil = mock(GitHubUtil.class);
-        GHRepository fork = mock(GHRepository.class);
-        when(fork.getBranch(any())).thenReturn(mock(GHBranch.class));
-        DockerfileGitHubUtil dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
-
-        dockerfileGitHubUtil.waitForExistingForkBranch(fork, "somebranch");
-        verify(gitHubUtil, times(0)).waitFor(TimeUnit.SECONDS.toMillis(1));
-    }
-
-    @Test
-    public void testWaitForExistingForkBranchWaits10SecondsForNullBranch() throws IOException, InterruptedException {
-        GitHubUtil gitHubUtil = mock(GitHubUtil.class);
-        GHRepository fork = mock(GHRepository.class);
-        when(fork.getBranch(any())).thenReturn(null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null);
-        DockerfileGitHubUtil dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
-
-        dockerfileGitHubUtil.waitForExistingForkBranch(fork, "somebranch");
-        verify(gitHubUtil, times(10)).waitFor(TimeUnit.SECONDS.toMillis(1));
-    }
-
-    @Test
     public void testThisUserIsOwner() throws IOException {
         GitHubUtil gitHubUtil = mock(GitHubUtil.class);
-        dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
+        DockerfileGitHubUtil dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
         String me = "me";
         GHRepository repo = mock(GHRepository.class);
         when(repo.getOwnerName()).thenReturn(me);
@@ -626,7 +561,7 @@ public class DockerfileGitHubUtilTest {
     @Test(expectedExceptions = IOException.class)
     public void testThisUserIsOwnerCantFindMyself() throws IOException {
         GitHubUtil gitHubUtil = mock(GitHubUtil.class);
-        dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
+        DockerfileGitHubUtil dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
         String me = "me";
         GHRepository repo = mock(GHRepository.class);
         when(repo.getOwnerName()).thenReturn(me);
@@ -635,5 +570,17 @@ public class DockerfileGitHubUtilTest {
         when(gitHubUtil.getMyself()).thenReturn(null);
 
         dockerfileGitHubUtil.thisUserIsOwner(repo);
+    }
+
+    @Test
+    public void testCreateOrUpdateForkBranchToParentDefault() throws InterruptedException {
+        GitHubUtil gitHubUtil = mock(GitHubUtil.class);
+        DockerfileGitHubUtil dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
+        GHRepository parent = mock(GHRepository.class);
+        String defaultBranch = "default";
+        when(parent.getDefaultBranch()).thenReturn(defaultBranch);
+        GHRepository fork = mock(GHRepository.class);
+        when(gitHubUtil.tryRetrievingBranch(parent, defaultBranch)).thenReturn(null);
+
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.3</version>
+                <version>3.2.4</version>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
This helps in a scenario where we haven't given GitHub / GHE the
requisite "5 seconds" to create its fork. We'll wait 10 seconds for an
extra buffer if we don't see that the parent's default branch is not in the fork.