### PR TITLE
Bump to newer codecov for resilience

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           name: dockerfile-image-update
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v1.0.10
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./dockerfile-image-update/target/site/jacoco/jacoco.xml


### PR DESCRIPTION
There are situations where codecov fails quite frequently during our process. While it's optional, it's annoying. Bump to the latest version which includes more retry logic and resiliency.