### PR TITLE
Revert "remove explicit population of GHRepository.parent since github-api does this now"

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/GitHubPullRequestSender.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/GitHubPullRequestSender.java
@@ -53,13 +53,19 @@ public class GitHubPullRequestSender {
             totalContentsFound++;
             parent = ghContent.getOwner();
             parentRepoName = parent.getFullName();
-            ShouldForkResult shouldForkResult = forkableRepoValidator.shouldFork(parent, ghContent, gitForkBranch);
-            if (shouldForkResult.isForkable()) {
-                contentsShouldFork++;
-                // fork the parent if not already forked
-                ensureForkedAndAddToListForProcessing(pathToDockerfilesInParentRepo, parent, parentRepoName, ghContent);
-            } else {
-                log.warn("Skipping {} because {}", parentRepoName, shouldForkResult.getReason());
+            // Refresh the repo to ensure that the object has full details
+            try {
+                parent = dockerfileGitHubUtil.getRepo(parentRepoName);
+                ShouldForkResult shouldForkResult = forkableRepoValidator.shouldFork(parent, ghContent, gitForkBranch);
+                if (shouldForkResult.isForkable()) {
+                    contentsShouldFork++;
+                    // fork the parent if not already forked
+                    ensureForkedAndAddToListForProcessing(pathToDockerfilesInParentRepo, parent, parentRepoName, ghContent);
+                } else {
+                    log.warn("Skipping {} because {}", parentRepoName, shouldForkResult.getReason());
+                }
+            } catch (IOException exception) {
+                log.warn("Could not refresh details of {}", parentRepoName);
             }
         }
 


### PR DESCRIPTION
This reverts commit 031a6334d0fe579c32bd74245d43d5b662f57c7c.

The default branch comes back as `null` from search results.

We still appear to need to fill in default branch data. Relevant
github-api bug: https://github.com/hub4j/github-api/issues/494

Reopens #158
Reverts #178