### PR TITLE
Hack GitHub search limitations

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -80,7 +80,22 @@ public class DockerfileGitHubUtil {
         if (query.substring(query.lastIndexOf(' ') + 1).length() <= 1) {
             throw new IOException("Invalid image name.");
         }
-        search.q("\"FROM " + query + "\"");
+        // Github search returns no results if your verbatim string contains more than two slashes
+        int start = 0;
+        while (start < query.length()) {
+            int slash1 = query.indexOf('/', start);
+            if (slash1 == -1) {
+                search.q((start == 0 ? "\"FROM " : "\"") + query.substring(start) + "\"");
+                break;
+            }
+            int slash2 = query.indexOf('/', slash1 + 1);
+            if (slash2 == -1) {
+                search.q((start == 0 ? "\"FROM " : "\"") + query.substring(start) + "\"");
+                break;
+            }
+            search.q((start == 0 ? "\"FROM " : "\"") + query.substring(start, slash2) + "\"");
+            start = slash2 + 1;
+        }
         log.debug("Searching for {}", query);
         PagedSearchIterable<GHContent> files = search.list();
         int totalCount = files.getTotalCount();


### PR DESCRIPTION
Hit a limit when using this against GCR repos where GitHub text search fails to find any `Dockerfile` with lines like:

```
FROM gcr.io/some-project/some-folder/some-image:tag
```

A github search for `FROM gcr.io/some-project` will find the repos, but a github search for `FROM gcr.io/some-project/some-folder` will not.

Hacky solution is to split on every second `/` and rely on the filtering effect of the initial `FROM`. This will give some false matches,  but the code that inspects the `Dockerfile`s for any potential changes will filter... only really a risk if you have 1000's of matches for that search