### PR TITLE
Add support for extra body content in PRs

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
@@ -69,6 +69,8 @@ public class CommandLine {
                 .help("message to provide for pull requests");
         parser.addArgument("-c")
                 .help("additional commit message for the commits in pull requests");
+        parser.addArgument("-B")
+                .help("additional body text to include in pull requests");
         return parser;
     }
 

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/PullRequestInfo.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/PullRequestInfo.java
@@ -13,8 +13,9 @@ public class PullRequestInfo {
     private final String title;
     private final String image;
     private final String tag;
+    private final String bodyExtra;
 
-    public PullRequestInfo(String title, String image, String tag) {
+    public PullRequestInfo(String title, String image, String tag, String bodyExtra) {
         if (title == null || title.trim().isEmpty()) {
             this.title = DEFAULT_TITLE;
         } else {
@@ -22,6 +23,7 @@ public class PullRequestInfo {
         }
         this.image = image;
         this.tag = tag;
+        this.bodyExtra = bodyExtra;
     }
 
     /**
@@ -36,8 +38,12 @@ public class PullRequestInfo {
      */
     public String getBody() {
         if (this.image == null && this.tag == null) {
-            return OLD_CONSTANT_BODY;
+            return appendBodyExtra(OLD_CONSTANT_BODY);
         }
-        return String.format(BODY_TEMPLATE, image, image, tag, image + ":" + tag);
+        return appendBodyExtra(String.format(BODY_TEMPLATE, image, image, tag, image + ":" + tag));
+    }
+
+    private String appendBodyExtra(String body) {
+        return bodyExtra == null || bodyExtra.trim().isEmpty() ? body : body + '\n' + bodyExtra;
     }
 }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -243,7 +243,7 @@ public class All implements ExecutableWithNamespace {
         if (isContentModified) {
             // Passing null for image/tag to temporarily maintain old behavior of using constant.
             PullRequestInfo pullRequestInfo =   
-                    new PullRequestInfo(ns.get(Constants.GIT_PR_TITLE),null, null);
+                    new PullRequestInfo(ns.get(Constants.GIT_PR_TITLE),null, null, ns.get(Constants.GIT_PR_BODY));
 
             dockerfileGitHubUtil.createPullReq(parent, branch, forkedRepo, pullRequestInfo);
         }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Child.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Child.java
@@ -49,7 +49,8 @@ public class Child implements ExecutableWithNamespace {
         PullRequestInfo pullRequestInfo =
                 new PullRequestInfo(ns.get(Constants.GIT_PR_TITLE),
                         gitForkBranch.getImageName(),
-                        gitForkBranch.getImageTag());
+                        gitForkBranch.getImageTag(),
+                        ns.get(Constants.GIT_PR_BODY));
 
         dockerfileGitHubUtil.createOrUpdateForkBranchToParentDefault(repo, fork, gitForkBranch);
 

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
@@ -128,7 +128,9 @@ public class Parent implements ExecutableWithNamespace {
         if (isContentModified) {
             PullRequestInfo pullRequestInfo =
                     new PullRequestInfo(ns.get(Constants.GIT_PR_TITLE),
-                            gitForkBranch.getImageName(), gitForkBranch.getImageTag());
+                            gitForkBranch.getImageName(),
+                            gitForkBranch.getImageTag(),
+                            ns.get(Constants.GIT_PR_BODY));
             // TODO: get the new PR number and cross post over to old ones
             dockerfileGitHubUtil.createPullReq(parent,
                     gitForkBranch.getBranchName(),

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
@@ -31,5 +31,6 @@ public class Constants {
     public static final String STORE_JSON_FILE = "store.json";
     public static final String GIT_AUTO_MERGE = "f";
     public static final String GIT_PR_TITLE = "m";
+    public static final String GIT_PR_BODY = "B";
     public static final String GIT_ADDITIONAL_COMMIT_MESSAGE = "c";
 }

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/PullRequestInfoTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/PullRequestInfoTest.java
@@ -10,35 +10,49 @@ public class PullRequestInfoTest {
     public static final String IMAGE = "myimage";
     public static final String TAG = "tag";
     public static final String TITLE = "title";
+    public static final String EXTRA = "extra";
 
     @Test
     public void testGetBody() {
         String imageAndTag = IMAGE + ":" + TAG;
-        PullRequestInfo pullRequestInfo = new PullRequestInfo(TITLE, IMAGE, TAG);
+        PullRequestInfo pullRequestInfo = new PullRequestInfo(TITLE, IMAGE, TAG, null);
         assertEquals(pullRequestInfo.getBody(), String.format(BODY_TEMPLATE, IMAGE, IMAGE, TAG, imageAndTag));
     }
 
     @Test
+    public void testGetBodyWithExtra() {
+        String imageAndTag = IMAGE + ":" + TAG;
+        PullRequestInfo pullRequestInfo = new PullRequestInfo(TITLE, IMAGE, TAG, EXTRA);
+        assertEquals(pullRequestInfo.getBody(), String.format(BODY_TEMPLATE, IMAGE, IMAGE, TAG, imageAndTag) + '\n' + EXTRA);
+    }
+
+    @Test
     public void testGetBodyIsOldConstantIfImageAndTagNull() {
-        PullRequestInfo pullRequestInfo = new PullRequestInfo(TITLE, null, null);
+        PullRequestInfo pullRequestInfo = new PullRequestInfo(TITLE, null, null, null);
         assertEquals(pullRequestInfo.getBody(), OLD_CONSTANT_BODY);
     }
 
     @Test
+    public void testGetBodyIsOldConstantWithExtraIfExtraSuppliedAndImageAndTagNull() {
+        PullRequestInfo pullRequestInfo = new PullRequestInfo(TITLE, null, null, EXTRA);
+        assertEquals(pullRequestInfo.getBody(), OLD_CONSTANT_BODY + '\n' + EXTRA);
+    }
+
+    @Test
     public void testGetTitle() {
-        PullRequestInfo pullRequestInfo = new PullRequestInfo(TITLE, IMAGE, TAG);
+        PullRequestInfo pullRequestInfo = new PullRequestInfo(TITLE, IMAGE, TAG, null);
         assertEquals(pullRequestInfo.getTitle(), TITLE);
     }
 
     @Test
     public void testGetDefaultTitleIfNull() {
-        PullRequestInfo pullRequestInfo = new PullRequestInfo(null, IMAGE, TAG);
+        PullRequestInfo pullRequestInfo = new PullRequestInfo(null, IMAGE, TAG, null);
         assertEquals(pullRequestInfo.getTitle(), DEFAULT_TITLE);
     }
 
     @Test
     public void testGetDefaultTitleIfEmpty() {
-        PullRequestInfo pullRequestInfo = new PullRequestInfo("   ", IMAGE, TAG);
+        PullRequestInfo pullRequestInfo = new PullRequestInfo("   ", IMAGE, TAG, null);
         assertEquals(pullRequestInfo.getTitle(), DEFAULT_TITLE);
     }
 }

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -485,7 +485,7 @@ public class DockerfileGitHubUtilTest {
 
         when(gitHubUtil.createPullReq(any(), anyString(), any(), anyString(), eq(Constants.PULL_REQ_ID))).thenReturn(-1, -1, -1, 0);
         dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
-        PullRequestInfo pullRequestInfo = new PullRequestInfo(null, null, null);
+        PullRequestInfo pullRequestInfo = new PullRequestInfo(null, null, null, null);
         dockerfileGitHubUtil.createPullReq(new GHRepository(), "branch", new GHRepository(), pullRequestInfo);
         verify(gitHubUtil, times(4)).createPullReq(any(), anyString(), any(), eq(DEFAULT_TITLE), eq(Constants.PULL_REQ_ID));
     }
@@ -506,7 +506,7 @@ public class DockerfileGitHubUtilTest {
         when(gitHubUtil.createPullReq(any(), anyString(), any(), anyString(), eq(Constants.PULL_REQ_ID))).thenReturn(1);
         doCallRealMethod().when(gitHubUtil).safeDeleteRepo(forkRepo);
         dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
-        PullRequestInfo pullRequestInfo = new PullRequestInfo(null, null, null);
+        PullRequestInfo pullRequestInfo = new PullRequestInfo(null, null, null, null);
         dockerfileGitHubUtil.createPullReq(new GHRepository(), "branch", forkRepo, pullRequestInfo);
         verify(gitHubUtil, times(1)).createPullReq(any(), anyString(), any(), anyString(), eq(Constants.PULL_REQ_ID));
         verify(forkRepo, times(1)).delete();


### PR DESCRIPTION
Adds the ability to add some extra text to the PR body.

Use case: we are using a separate bot account to run the pull requests, so we need visibility into the PRs that get created in order to ensure that they get some attention. Also for the case where the teams managing the repos against which the PRs are created, we need the ability to point them at where the PRs originate from so that they have tracability on who to blame if the PRs become a nusance