### PR TITLE
Auto-label PRs / Update release-drafter.yml to have a heading in releases

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,18 +1,20 @@
 # Configuration for labeler - https://github.com/actions/labeler
 dependencies:
-- *pom.xml
+- ./**/pom.xml
+- pom.xml
 
 chore:
 - .github/**/*
-- *.sh
+- ./*.sh
 - Makefile
 - ./*.yml
-- *.enc
+- ./*.enc
 - .gitignore
 - Dockerfile*
 
 documentation: 
-- *.md
+- ./*.md
+- ./**/*.md
 - ./*.txt
 
 tests:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,20 @@
+# Configuration for labeler - https://github.com/actions/labeler
+dependencies:
+- *pom.xml
+
+chore:
+- .github/**/*
+- *.sh
+- Makefile
+- ./*.yml
+- *.enc
+- .gitignore
+- Dockerfile*
+
+documentation: 
+- *.md
+- ./*.txt
+
+tests:
+- dockerfile-image-update-itest/**/*
+- dockerfile-image-update/src/test/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,9 +8,19 @@ chore:
 - ./*.sh
 - Makefile
 - ./*.yml
+- .ci.settings.xml
 - ./*.enc
 - .gitignore
 - Dockerfile*
+
+ci-cd:
+- .github/workflows/**/*
+- .ci.deploy.sh
+- .ci.prepare-ssh-gpg.sh
+- .ci.settings.xml
+- Dockerfile*
+- ./*.enc
+- ./*.yml
 
 documentation: 
 - ./*.md

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -23,6 +23,7 @@ categories:
     labels:
       - enhancement
       - feature
+      - improvement
       - rfe
   - title: 🐛 Bug Fixes
     labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -53,6 +53,7 @@ exclude-labels:
   - invalid
 
 template: |
+  ## Changes
   <!-- Optional: add a release summary here -->
   $CHANGES
 replacers:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,11 +1,16 @@
 name: 'Multi-Module Maven Build / Deploy'
 on:
   push:
+    paths-ignore:
+    - 'CODE_OF_CONDUCT.md'
+    - 'LICENSE.txt'
+    - 'README.md'
+    - 'SECURITY.md'
     branches:
-      - master
+      - $default-branch
   pull_request:
     branches:
-      - master
+      - $default-branch
 jobs:
   build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,11 +6,9 @@ on:
     - 'LICENSE.txt'
     - 'README.md'
     - 'SECURITY.md'
-    branches:
-      - $default-branch
+    branches: [ $default-branch ]
   pull_request:
-    branches:
-      - $default-branch
+    branches: [ $default-branch ]
 jobs:
   build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,9 +6,11 @@ on:
     - 'LICENSE.txt'
     - 'README.md'
     - 'SECURITY.md'
-    branches: [ $default-branch ]
+    branches:
+      - master
   pull_request:
-    branches: [ $default-branch ]
+    branches:
+      - master
 jobs:
   build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,8 +2,19 @@ name: "Code scanning - action"
 
 on:
   push:
+    branches: [ $default-branch ]
   pull_request:
+    branches: [ $default-branch ]
   schedule:
+    #        ┌───────────── minute (0 - 59)
+    #        │  ┌───────────── hour (0 - 23)
+    #        │  │ ┌───────────── day of the month (1 - 31)
+    #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        *  * * * *
     - cron: '0 16 * * 6'
 
 jobs:
@@ -20,11 +31,6 @@ jobs:
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
-      
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,11 @@ name: "Code scanning - action"
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches:
+      - master
   pull_request:
-    branches: [ $default-branch ]
+    branches:
+      - master
   schedule:
     #        ┌───────────── minute (0 - 59)
     #        │  ┌───────────── hour (0 - 23)

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,18 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler/blob/master/README.md
+
+name: "Pull Request Labeler"
+on:
+- pull_request
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -7,7 +7,8 @@
 
 name: "Pull Request Labeler"
 on:
-- pull_request
+  pull_request:
+    branches: [ $default-branch ]
 
 jobs:
   triage:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -8,7 +8,8 @@
 name: "Pull Request Labeler"
 on:
   pull_request:
-    branches: [ $default-branch ]
+    branches:
+      - master
 
 jobs:
   triage:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,7 +2,8 @@ name: Release Drafter
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches:
+      - master
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,8 +2,7 @@ name: Release Drafter
 
 on:
   push:
-    branches:
-      - master
+    branches: [ $default-branch ]
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
Labeling PRs will group them into headings but we didn't have a primary heading. 

This will auto-label PRs based on file paths so we have a bit less label management tied into our release drafter process.