### PR TITLE
Fix: Entrypoint properly passes container args

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env sh
-exec java -jar /dockerfile-image-update-${MVN_VERSION}.jar $@
+set -x
+exec java -jar /dockerfile-image-update-${MVN_VERSION}.jar "$@"


### PR DESCRIPTION
The entrypoint script was not quoting the arg variable. This led to
reinterpretation of the args.

Also added `set -x` to show the command at the beginning. I could easily
be convinced not to do this but it doesn't seem overtly harmful.

Fixes #198