### PR TITLE
Don't release dockerfile-image-update-itest module

### DIFF
--- a/.ci.deploy.sh
+++ b/.ci.deploy.sh
@@ -28,7 +28,7 @@ docker run --rm -v "${PWD}":/usr/src/build \
                 -e GPG_KEY_NAME \
                 -e GPG_PASSPHRASE \
                 maven:3.6-jdk-"${JDK_VERSION}" \
-                /bin/bash -c "source .ci.prepare-ssh-gpg.sh && mvn --quiet --batch-mode releaser:release"
+                /bin/bash -c "source .ci.prepare-ssh-gpg.sh && mvn --quiet --batch-mode --projects '!dockerfile-image-update-itest' releaser:release"
 
 # Get MVN_VERSION
 MVN_VERSION=$(cat ./dockerfile-image-update/target/classes/version.txt)


### PR DESCRIPTION
It seems highly unlikely that this would get consumed from Maven Central
and it just pollutes the tags and releases for this repo. Ideally, the
next step would be to merge dockerfile-image-update with
dockerfile-image-update-parent because we don't really have enough here
for the aggregation pattern (in my opinion, at least). This would lead
to cleaner releases and a bit less waste. The itest project really is
primarily just a product of our CI/CD flow.