### PR TITLE
Handle GitHub search limit: dashes in image name

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/search/GitHubImageSearchTermList.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/search/GitHubImageSearchTermList.java
@@ -116,7 +116,7 @@ public class GitHubImageSearchTermList {
      */
     static class ProcessingState {
         final List<String> terms = new ArrayList<>();
-        private StringBuffer termBuffer = new StringBuffer();
+        private final StringBuffer termBuffer = new StringBuffer();
 
         /**
          * Add to the current search term
@@ -139,7 +139,7 @@ public class GitHubImageSearchTermList {
          */
         void finalizeCurrentTerm() {
             terms.add(termBuffer.toString());
-            termBuffer = new StringBuffer();
+            termBuffer.setLength(0);
         }
     }
 }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/search/GitHubImageSearchTermList.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/search/GitHubImageSearchTermList.java
@@ -1,0 +1,109 @@
+package com.salesforce.dockerfileimageupdate.search;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GitHubImageSearchTermList {
+    /**
+     * We need to split out search terms to accomodate how GitHub code search works
+     * https://docs.github.com/en/github/searching-for-information-on-github/searching-code#considerations-for-code-search
+     *
+     * Essentially we'll split out any dashes in the registry domain and split out any url segments with dashes by
+     * removing the slashes surrounding them to make them an independent search term.
+     *
+     * The overarching goal here is to make sure we try and keep our search space down since GitHub Code Search will
+     * only return up to about 1000 results.
+     * Reference: #169 and https://developer.github.com/v3/search/#about-the-search-api
+     *
+     * @param image the name of the image including registry
+     * @return list of GitHub code search terms
+     */
+    public static List<String> getSearchTerms(String image) {
+        if (image == null || image.trim().isEmpty()) {
+            return ImmutableList.of();
+        }
+        String[] imageParts = image.split("/");
+        ProcessingState state = processDomainPartOfImage(imageParts[0]);
+        if (imageParts.length > 1) {
+            for (int i = 1; i < imageParts.length - 1; i++) {
+                if (imageParts[i].contains("-")) {
+                    state.finalizeCurrentTerm();
+                } else {
+                    state.addToCurrentTerm("/");
+                }
+                state.addToCurrentTerm(imageParts[i]);
+            }
+            String leftoverTerm = state.getCurrentTerm();
+            if (leftoverTerm.contains("-")) {
+                state.finalizeCurrentTerm();
+            }
+            state.addToCurrentTerm("/");
+            state.addToCurrentTerm(imageParts[imageParts.length - 1]);
+        }
+        state.finalizeCurrentTerm();
+        return state.terms;
+    }
+
+    /**
+     * Domains with dashes do not function well with GitHub code search
+     * https://docs.github.com/en/github/searching-for-information-on-github/searching-code#considerations-for-code-search
+     *
+     * Unfortunately, code search is not implemented in any other way such as GraphQL
+     *
+     * @param domain the domain part of the image (which may or may not be the full registry name)
+     * @return processing state for the search terms
+     */
+    static ProcessingState processDomainPartOfImage(String domain) {
+        ProcessingState state = new ProcessingState();
+        if (domain == null || domain.trim().isEmpty()) {
+            return state;
+        } else {
+            state.addToCurrentTerm("FROM ");
+            String leftoverDomain = domain;
+            if (domain.contains("-")) {
+                String[] domainParts = domain.split("-");
+                for (int i = 0; i < domainParts.length - 1; i++) {
+                    state.addToCurrentTerm(domainParts[i]);
+                    state.finalizeCurrentTerm();
+                }
+                leftoverDomain = domainParts[domainParts.length - 1];
+            }
+            state.addToCurrentTerm(leftoverDomain);
+        }
+        return state;
+    }
+
+    /**
+     * Helper class to store processing state of a search term or terms
+     */
+    static class ProcessingState {
+        final List<String> terms = new ArrayList<>();
+        private StringBuffer termBuffer = new StringBuffer();
+
+        /**
+         * Add to the current search term
+         * @param segment segment to add to the current search term
+         */
+        void addToCurrentTerm(String segment) {
+            termBuffer.append(segment);
+        }
+
+        /**
+         * Get the current term as it stands right now
+         * @return current term
+         */
+        String getCurrentTerm() {
+            return termBuffer.toString();
+        }
+
+        /**
+         * This will finalize the current term by adding it to the list and prepping for a new empty term
+         */
+        void finalizeCurrentTerm() {
+            terms.add(termBuffer.toString());
+            termBuffer = new StringBuffer();
+        }
+    }
+}

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Multimap;
 import com.salesforce.dockerfileimageupdate.model.FromInstruction;
 import com.salesforce.dockerfileimageupdate.model.GitForkBranch;
 import com.salesforce.dockerfileimageupdate.model.PullRequestInfo;
+import com.salesforce.dockerfileimageupdate.search.GitHubImageSearchTermList;
 import com.salesforce.dockerfileimageupdate.storage.GitHubJsonStore;
 import org.kohsuke.github.*;
 import org.slf4j.Logger;
@@ -68,7 +69,7 @@ public class DockerfileGitHubUtil {
         return gitHubUtil.getRepo(repoName);
     }
 
-    public PagedSearchIterable<GHContent> findFilesWithImage(String query, String org) throws IOException {
+    public PagedSearchIterable<GHContent> findFilesWithImage(String image, String org) throws IOException {
         GHContentSearchBuilder search = gitHubUtil.startSearch();
         // Filename search appears to yield better / more results than language:Dockerfile
         // Root cause: linguist doesn't currently deal with prefixes of files:
@@ -77,17 +78,18 @@ public class DockerfileGitHubUtil {
         if (org != null) {
             search.user(org);
         }
-        if (query.substring(query.lastIndexOf(' ') + 1).length() <= 1) {
+        if (image.substring(image.lastIndexOf(' ') + 1).length() <= 1) {
             throw new IOException("Invalid image name.");
         }
-        search.q("\"FROM " + query + "\"");
-        log.debug("Searching for {}", query);
+        List<String> terms = GitHubImageSearchTermList.getSearchTerms(image);
+        log.info("Searching for {} with terms: {}", image, terms);
+        terms.forEach(search::q);
         PagedSearchIterable<GHContent> files = search.list();
         int totalCount = files.getTotalCount();
         if (totalCount > 1000) {
             log.warn("Number of search results is above 1000! The GitHub Search API will only return around 1000 results - https://developer.github.com/v3/search/#about-the-search-api");
         }
-        log.info("Number of files found for {}:{}", query, totalCount);
+        log.info("Number of files found for {}: {}", image, totalCount);
         return files;
     }
 

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/search/GitHubImageSearchTermListTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/search/GitHubImageSearchTermListTest.java
@@ -1,0 +1,68 @@
+package com.salesforce.dockerfileimageupdate.search;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+public class GitHubImageSearchTermListTest {
+    @DataProvider
+    public Object[][] imageAndParts() {
+        return new Object[][]{
+                {null, ImmutableList.of()},
+                {"", ImmutableList.of()},
+                {"dockerimage", ImmutableList.of("FROM dockerimage")},
+                {"gcr.io/i/am/a/container/image", ImmutableList.of("FROM gcr.io/i/am/a/container/image")},
+                {"gcr.io/the-dash", ImmutableList.of("FROM gcr.io/the-dash")},
+                {"gcr.io/thedash/the-mash", ImmutableList.of("FROM gcr.io/thedash/the-mash")},
+                {"someregistry.tld/omundoebao", ImmutableList.of("FROM someregistry.tld/omundoebao")},
+                {"gcr.io/some-project/some-folder/some-image", ImmutableList.of("FROM gcr.io", "some-project", "some-folder", "/some-image")},
+                {"gcr.io/the-dash/the-mash", ImmutableList.of("FROM gcr.io", "the-dash", "/the-mash")},
+                {"gcr.io/the-dash/themash", ImmutableList.of("FROM gcr.io", "the-dash", "/themash")},
+                {"some-registry.some.dashy.tld/someimage/with-dashes", ImmutableList.of("FROM some", "registry.some.dashy.tld/someimage/with-dashes")},
+                {"this-registry-has-dashes.somecompany.io/rv-python-runtime", ImmutableList.of("FROM this", "registry", "has", "dashes.somecompany.io/rv-python-runtime")},
+                {"this-registry-has-dashes.some-company.with-dashes.io/rv-python-runtime", ImmutableList.of("FROM this", "registry", "has", "dashes.some", "company.with", "dashes.io/rv-python-runtime")},
+                {"this-registry-has-dashes.some-company.with-dashes.io/some-path/with-more-dashes/rv-python-runtime", ImmutableList.of("FROM this", "registry", "has", "dashes.some", "company.with", "dashes.io", "some-path", "with-more-dashes", "/rv-python-runtime")},
+                {"this-registry-has-dashes.some-company.with-dashes.io/somepath/with-more-dashes/rv-python-runtime", ImmutableList.of("FROM this", "registry", "has", "dashes.some", "company.with", "dashes.io/somepath", "with-more-dashes", "/rv-python-runtime")},
+        };
+    }
+
+    @Test(dataProvider = "imageAndParts")
+    public void testGetSearchTermsContent(String image, List<String> expectedResult) {
+        List<String> searchTerms = GitHubImageSearchTermList.getSearchTerms(image);
+        assertEquals(joinListByComma(searchTerms), joinListByComma(expectedResult));
+    }
+
+    private String joinListByComma(List<String> list) {
+        return String.join(", ", list);
+    }
+
+    @Test(dataProvider = "imageAndParts")
+    public void testGetSearchTermsSize(String image, List<String> expectedResult) {
+        List<String> searchTerms = GitHubImageSearchTermList.getSearchTerms(image);
+        assertEquals(searchTerms, expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] domainCurrentTermAndProcessedTerms() {
+        return new Object[][]{
+                {null, "", ImmutableList.of()},
+                {"", "", ImmutableList.of()},
+                {"dockerimage", "FROM dockerimage", ImmutableList.of()},
+                {"someregistry.tld", "FROM someregistry.tld", ImmutableList.of()},
+                {"gcr.io", "FROM gcr.io", ImmutableList.of()},
+                {"this-registry-has-dashes.somecompany.io", "dashes.somecompany.io", ImmutableList.of("FROM this", "registry", "has")},
+                {"this-registry-has-dashes.some-company.with-dashes.io", "dashes.io", ImmutableList.of("FROM this", "registry", "has", "dashes.some", "company.with")},
+        };
+    }
+
+    @Test(dataProvider = "domainCurrentTermAndProcessedTerms")
+    public void testProcessDomainPartOfImage(String domain, String expectedCurrentTerm, List<String> expectedProcessedTerms) {
+        GitHubImageSearchTermList.ProcessingState state = GitHubImageSearchTermList.processDomainPartOfImage(domain);
+        assertEquals(joinListByComma(state.terms), joinListByComma(expectedProcessedTerms));
+        assertEquals(state.getCurrentTerm(), expectedCurrentTerm);
+    }
+}


### PR DESCRIPTION
Per #191 and #210, there are a couple of limitations in GitHub search
that effectively limit the ability of DFIU to find code results.

By combining known domain patterns and noting the limitations documented
in https://docs.github.com/en/github/searching-for-information-on-github/searching-code#considerations-for-code-search
this change does some treatment of image names. It treats the TLD and
remaining URL segments slightly different.

The domain will be split into parts by dashes while we'll attempt to
split the remaining url parts by slashes if they have dashes in them.
Meanwhile, we'll attempt to keep the search terms down to a minimum if
possible.

A fair number of working use cases based on manual testing can be
found in the unit tests but working and non-working tests are also
documented in #191 and #210. Some PRs have been created as a result of
this after these changes:
* https://github.com/justinharringa/somecontainers/pull/9
* https://github.com/justinharringa/somecontainers/pull/10
* https://github.com/justinharringa/somecontainers/pull/11
* https://github.com/justinharringa/somecontainers/pull/12
* https://github.com/justinharringa/somecontainers/pull/13

Fixes #210