### PR TITLE
Move release process to manual dispatch, fix PR XP for labeler / CodeClimate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: "dockerfile-image-update"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,103 @@
+name: 'Build / Integration Test'
+on:
+  push:
+    paths-ignore:
+    - 'CODE_OF_CONDUCT.md'
+    - 'LICENSE.txt'
+    - 'README.md'
+    - 'SECURITY.md'
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'dockerfile-image-update-') == false
+    steps:
+      - name: checkout
+        uses: actions/checkout@master
+        with:
+          ref: ${{ github.ref }}
+      - name: docker build
+        run: make mvn-docker-build get-main-project-dirs
+      - name: Upload main module
+        uses: actions/upload-artifact@v1
+        with:
+          name: dockerfile-image-update
+          path: dockerfile-image-update
+      - name: Upload itest module
+        uses: actions/upload-artifact@v1
+        with:
+          name: dockerfile-image-update-itest
+          path: dockerfile-image-update-itest
+  get-next-version:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'dockerfile-image-update-') == false
+    outputs:
+      version: ${{ steps.version_tag.outputs.new_version }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: get version
+        id:   version_tag
+        run: |
+          make get-new-version-from-tag
+          echo "::set-output name=new_version::$(cat new_patch_version.txt)"
+  integration-test:
+    runs-on: ubuntu-latest
+    needs: [build-test, get-next-version]
+    steps:
+      - name: checkout
+        uses: actions/checkout@master
+        with:
+          ref: ${{ github.ref }}
+      - name: Download itest dir
+        uses: actions/download-artifact@v1
+        with:
+          name: dockerfile-image-update-itest
+      - name: integration test
+        env:
+          ITEST_GH_TOKEN: ${{ secrets.ITEST_GH_TOKEN }}
+        run: echo "Testing new version ${{ needs.get-next-version.outputs.version }}" && make integration-test
+  codecov:
+    runs-on: ubuntu-latest
+    needs: build-test
+    steps:
+      - name: Download main project dir
+        uses: actions/download-artifact@v1
+        with:
+          name: dockerfile-image-update
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1.0.10
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./dockerfile-image-update/target/site/jacoco/jacoco.xml
+          # flags: unittests
+          # yml: ./codecov.yml
+          fail_ci_if_error: true
+  codeclimate:
+    runs-on: ubuntu-latest
+    needs: build-test
+    steps:
+      - name: checkout
+        uses: actions/checkout@master
+        with:
+          ref: ${{ github.ref }}
+      - name: Download main project dir
+        uses: actions/download-artifact@v1
+        with:
+          name: dockerfile-image-update
+      - name: Upload coverage to Code Climate
+        uses: paambaati/codeclimate-action@v2.6.0
+        env:
+          CC_TEST_REPORTER_ID: 873529a2ad74a48f14a73b29dd3f392c7da63902534ac0fd224746f32ba77ac5
+          JACOCO_SOURCE_PATH: "${{github.workspace}}/dockerfile-image-update/src/main/java"
+        with:
+          # The report file must be there, otherwise Code Climate won't find it
+          coverageCommand: echo "already done"
+          coverageLocations: |
+            ${{github.workspace}}/dockerfile-image-update/target/site/jacoco/jacoco.xml:jacoco

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: 'Build / Integration Test'
+name: 'Build + Integration Test'
 on:
   push:
     paths-ignore:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -4,10 +4,15 @@
 # To use this workflow, you will need to set up a .github/labeler.yml
 # file with configuration.  For more information, see:
 # https://github.com/actions/labeler/blob/master/README.md
-
+#
+# Runs on `pull_request_target` to get a write token. This is safe since we're not checking
+# out any arbitrary git repos.
+# References:
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+# https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-797125425
 name: "Pull Request Labeler"
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,6 @@
-name: 'Multi-Module Maven Build / Deploy'
-on:
-  push:
-    paths-ignore:
-    - 'CODE_OF_CONDUCT.md'
-    - 'LICENSE.txt'
-    - 'README.md'
-    - 'SECURITY.md'
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+name: 'Release new version'
+on: workflow_dispatch
+
 jobs:
   build-test:
     runs-on: ubuntu-latest
@@ -63,46 +53,8 @@ jobs:
         env:
           ITEST_GH_TOKEN: ${{ secrets.ITEST_GH_TOKEN }}
         run: echo "Testing new version ${{ needs.get-next-version.outputs.version }}" && make integration-test
-  codecov:
-    runs-on: ubuntu-latest
-    needs: build-test
-    steps:
-      - name: Download main project dir
-        uses: actions/download-artifact@v1
-        with:
-          name: dockerfile-image-update
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1.0.10
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./dockerfile-image-update/target/site/jacoco/jacoco.xml
-          # flags: unittests
-          # yml: ./codecov.yml
-          fail_ci_if_error: true
-  codeclimate:
-    runs-on: ubuntu-latest
-    needs: build-test
-    steps:
-      - name: checkout
-        uses: actions/checkout@master
-        with:
-          ref: ${{ github.ref }}
-      - name: Download main project dir
-        uses: actions/download-artifact@v1
-        with:
-          name: dockerfile-image-update
-      - name: Upload coverage to Code Climate
-        uses: paambaati/codeclimate-action@v2.6.0
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}
-          JACOCO_SOURCE_PATH: "${{github.workspace}}/dockerfile-image-update/src/main/java"
-        with:
-          # The report file must be there, otherwise Code Climate won't find it
-          coverageCommand: echo "already done"
-          coverageLocations: |
-            ${{github.workspace}}/dockerfile-image-update/target/site/jacoco/jacoco.xml:jacoco
-  master-deploy:
-    needs: [integration-test, get-next-version]
+  deploy:
+    needs: [ integration-test, get-next-version ]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     steps:

--- a/README.md
+++ b/README.md
@@ -181,6 +181,23 @@ Before you run the integration tests (locally):
     ```
     make itest-local-changes
     ```
+    
+#### Release Process
+We currently use GitHub Actions and Releases. In order to collect dependency
+updates from dependabot and any other minor changes, we've switched to a process
+to manually trigger the release process. For now, that looks like the following:
+* PRs continually get updated with labels by [Pull Request Labeler](https://github.com/actions/labeler)
+  and that helps set us up for nice release notes by [Release Drafter](https://github.com/release-drafter/release-drafter).
+* After PRs have been merged to the primary branch, go to the Actions tab and 
+  trigger the `Release new version` Workflow. This will build, integration test, 
+  deploy the latest version to Docker Hub and Maven Central, and tag that commit 
+  hash with the next semantic version.
+* Once that release has been tagged you can go to the draft release which is 
+  continually updated by [Release Drafter](https://github.com/release-drafter/release-drafter)
+  and select the latest tag to associate with that release. Change the version to 
+  reflect the same version as the tag (`1.0.${NEW_VERSION}`). Ideally we'll automate
+  this to run at the end of the triggered workflow.
+  
 
 Blogs / Slides
 ==============

--- a/README.md
+++ b/README.md
@@ -190,12 +190,10 @@ to manually trigger the release process. For now, that looks like the following:
 
 * PRs continually get updated with labels by [Pull Request Labeler](https://github.com/actions/labeler)
   and that helps set us up for nice release notes by [Release Drafter](https://github.com/release-drafter/release-drafter).
-
 * After PRs have been merged to the primary branch, go to the Actions tab
   and trigger the `Release new version` Workflow. This will build,
   integration test, deploy the latest version to Docker Hub and Maven
   Central, and tag that commit hash with the next semantic version.
-
 * Once that release has been tagged you can go to the draft release which
   is continually updated by [Release Drafter](https://github.com/release-drafter/release-drafter)
   and select the latest tag to associate with that release. Change the

--- a/README.md
+++ b/README.md
@@ -6,68 +6,115 @@
 
 # Dockerfile Image Updater
 
-This tool provides a mechanism to make security updates to docker images at scale. The tool searches github for declared docker images and sends pull requests to projects that are not using the desired version of the requested docker image.
+This tool provides a mechanism to make security updates to docker images at
+scale. The tool searches github for declared docker images and sends pull
+requests to projects that are not using the desired version of the requested
+docker image.
 
-Docker builds images using a declared Dockerfile. Within the Dockerfile, there is a `FROM` declaration that specifies the base image and a tag that will be used as the starting layers for the new image. If the base image that `FROM` depends on is rebuilt, the Docker images that depend on it will never be updated with the newer layers. This becomes a major problem if the reason the base image was updated was to fix a security vulnerability. All Docker images are often based on operating system libraries and these get patched for security updates quite frequently. This tool, the Dockerfile Image Updater was created to automatically make sure that child images are updated when the images they depend on get updated.
+Docker builds images using a declared Dockerfile. Within the Dockerfile,
+there is a `FROM` declaration that specifies the base image and a tag that
+will be used as the starting layers for the new image. If the base image that
+`FROM` depends on is rebuilt, the Docker images that depend on it will never
+be updated with the newer layers. This becomes a major problem if the reason
+the base image was updated was to fix a security vulnerability. All Docker
+images are often based on operating system libraries and these get patched
+for security updates quite frequently. This tool, the Dockerfile Image Updater
+was created to automatically make sure that child images are updated when the
+images they depend on get updated.
 
 ## Table of contents
 
- * [User Guide](#user-guide)
-    * [What It Does](#what-it-does)
-    * [Prerequisites](#prerequisites)
-    * [Precautions](#precautions)
-    * [How To Use It](#how-to-use-it)
- * [Developer Guide](#developer-guide)
-    * [Building](#building)
-    * [Running locally](#running-locally)
-    * [Creating a New Feature](#creating-a-new-feature)
-    * [Running Unit Tests](#running-unit-tests)
-    * [Running Integration Tests](#running-integration-tests)
- * [Blogs / Slides](#blogs--slides)
- 
-User Guide
-==========
+* [User Guide](#user-guide)
+  * [What It Does](#what-it-does)
+  * [Prerequisites](#prerequisites)
+  * [Precautions](#precautions)
+  * [How To Use It](#how-to-use-it)
+* [Developer Guide](#developer-guide)
+  * [Building](#building)
+  * [Running locally](#running-locally)
+  * [Creating a New Feature](#creating-a-new-feature)
+  * [Running Unit Tests](#running-unit-tests)
+  * [Running Integration Tests](#running-integration-tests)
+* [Blogs / Slides](#blogs--slides)
+
+## User Guide
+
 ### What it does
+
 The tool has three modes
- 1. `all` - Reads store that declares the docker images and versions that you intend others to use. 
- Example:
-```commandline
-export git_api_url=https://api.github.com
-export git_api_token=my_github_token
-docker run --rm -e git_api_token -e git_api_url salesforce/dockerfile-image-update all image-to-tag-store
-```
- 2. `parent` - Searches github for images that use a specified image name and sends pull requests if the image tag doesn't match intended tag. The intended image with tag is passed in the command line parameters. The intended image-to-tag mapping is persisted in a store in a specified git repository under the token owner. 
-Example:
-```commandline
-export git_api_url=https://api.github.com
-export git_api_token=my_github_token
-docker run --rm -e git_api_token -e git_api_url salesforce/dockerfile-image-update parent my_org/my_image v1.0.1 image-to-tag-store
-```
- 3. `child` - Given a specific git repo, sends a pull request to update the image to a given version. You can optionally persist the image version combination in the image-to-tag store. 
-Example:
-```commandline
-export git_api_url=https://api.github.com
-export git_api_token=my_github_token
-docker run --rm -e git_api_token -e git_api_url salesforce/dockerfile-image-update child my_gh_org/my_gh_repo my_image_name v1.0.1
-```
+
+1. `all` - Reads store that declares the docker images and versions that you
+   intend others to use.
+
+   Example:
+
+   ```commandline
+   export git_api_url=https://api.github.com
+   export git_api_token=my_github_token
+   docker run --rm -e git_api_token -e git_api_url \
+     salesforce/dockerfile-image-update all image-to-tag-store
+   ```
+
+1. `parent` - Searches github for images that use a specified image name and
+   sends pull requests if the image tag doesn't match intended tag. The
+   intended image with tag is passed in the command line parameters. The
+   intended image-to-tag mapping is persisted in a store in a specified git
+   repository under the token owner.
+
+   Example:
+
+   ```commandline
+   export git_api_url=https://api.github.com
+   export git_api_token=my_github_token
+   docker run --rm -e git_api_token -e git_api_url \
+     salesforce/dockerfile-image-update parent my_org/my_image v1.0.1 \
+     image-to-tag-store
+   ```
+
+1. `child` - Given a specific git repo, sends a pull request to update the
+   image to a given version. You can optionally persist the image version
+   combination in the image-to-tag store.
+
+   Example:
+
+   ```commandline
+   export git_api_url=https://api.github.com
+   export git_api_token=my_github_token
+   docker run --rm -e git_api_token -e git_api_url \
+     salesforce/dockerfile-image-update child my_gh_org/my_gh_repo \
+     my_image_name v1.0.1
+   ```
 
 ### Prerequisites
+
 In environment variables, please provide:
- * `git_api_token` : This is your GitHub token to your account. Set these privileges by: going to your GitHub account --> settings --> Personal access tokens --> check `repo` and `delete_repo`.
- * `git_api_url` : This is the Endpoint URL of the GitHub API. In general GitHub, this is `https://api.github.com/`; for Enterprise, this should be `https://hostname/api/v3`. (this variable is optional; you can provide it through the command line.)
+
+* `git_api_token` : This is your GitHub token to your account. Set these
+  privileges by: going to your GitHub account --> settings -->
+  Personal access tokens --> check `repo` and `delete_repo`.
+* `git_api_url` : This is the Endpoint URL of the GitHub API. In general
+  GitHub, this is `https://api.github.com/`; for Enterprise, this should
+  be `https://hostname/api/v3`. (this variable is optional; you can provide it
+  through the command line.)
 
 ### Precautions
-1. This tool may create a LOT of forks in your account. All pull requests created are through a fork on your own account.
-2. We currently do not operate on forked repositories due to limitations in forking a fork on GitHub.
-We should invest some time in doing this right. See [issue #21](https://github.com/salesforce/dockerfile-image-update/issues/22) 
-3. Submodules are separate repositories and get their own pull requests.
+
+1. This tool may create a LOT of forks in your account. All pull requests
+   created are through a fork on your own account.
+1. We currently do not operate on forked repositories due to limitations in
+   forking a fork on GitHub. We should invest some time in doing this right.
+   See [issue #21](https://github.com/salesforce/dockerfile-image-update/issues/22)
+1. Submodules are separate repositories and get their own pull requests.
 
 ### How to use it
+
 Our recommendation is to run it as a docker container:
+
 ```commandline
 export git_api_url=https://api.github.com
 export git_api_token=my_github_token
-docker run --rm -e git_api_token -e git_api_url salesforce/dockerfile-image-update <COMMAND> <PARAMETERS>
+docker run --rm -e git_api_token -e git_api_url \
+  salesforce/dockerfile-image-update <COMMAND> <PARAMETERS>
 ```
 
 ```commandline
@@ -94,7 +141,10 @@ subcommands:
 ```
 
 #### The `all` command
-Specify an image-to-tag store (a repository name on GitHub that contains a file called store.json); looks through the JSON file and checks/updates all the base images in GitHub to the tag in the store.
+
+Specify an image-to-tag store (a repository name on GitHub that contains a
+file called store.json); looks through the JSON file and checks/updates all
+the base images in GitHub to the tag in the store.
 
 ```commandline
 usage: dockerfile-image-update all [-h] <IMG_TAG_STORE>
@@ -107,7 +157,9 @@ optional arguments:
 ```
 
 #### The `child` command
-Forcefully updates a repository's Dockerfile(s) to given tag. If specified a store, it will also forcefully update the store.
+
+Forcefully updates a repository's Dockerfile(s) to given tag. If specified a
+store, it will also forcefully update the store.
 
 ```commandline
 usage: dockerfile-image-update child [-h] [-s <IMG_TAG_STORE>] <GIT_REPO> <IMG> <FORCE_TAG>
@@ -123,7 +175,10 @@ optional arguments:
 ```
 
 #### The `parent` command
-Given an image, tag, and store, it will create pull requests for any Dockerfiles that has the image as a base image and an outdated tag. It also updates the store. 
+
+Given an image, tag, and store, it will create pull requests for any
+Dockerfiles that has the image as a base image and an outdated tag. It also
+updates the store.
 
 ```commandline
 usage: dockerfile-image-update parent [-h] <IMG> <TAG> <IMG_TAG_STORE>
@@ -137,9 +192,10 @@ optional arguments:
   -h, --help             show this help message and exit
 ```
 
-Developer Guide
-===============
+## Developer Guide
+
 ### Building
+
 ```commandline
 git clone https://github.com/salesforce/dockerfile-image-update.git
 cd dockerfile-image-update
@@ -147,41 +203,55 @@ mvn clean install
 ```
 
 ### Running locally
+
 ```commandline
 cd dockerfile-image-update/target
 java -jar dockerfile-image-update-1.0-SNAPSHOT.jar <COMMAND> <PARAMETERS>
 ```
 
 ### Creating a new feature
-Under [dockerfile-image-update/src/main/java/com/salesforce/dva/dockerfileimageupdate/subcommands/impl](https://github.com/salesforce/dockerfile-image-update/tree/master/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl), 
-create a new class `YOUR_FEATURE.java`. Make sure it implements `ExecutableWithNamespace` and has the `SubCommand` 
-annotation with a `help`, `requiredParams`, and `optionalParams`. Then, under the `execute` method, code what you want this tool to do.
+
+Under [dockerfile-image-update/src/main/java/com/salesforce/dva/dockerfileimageupdate/subcommands/impl](https://github.com/salesforce/dockerfile-image-update/tree/master/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl),
+create a new class `YOUR_FEATURE.java`.
+Make sure it implements `ExecutableWithNamespace` and has the `SubCommand`
+annotation with a `help`, `requiredParams`, and `optionalParams`.
+Then, under the `execute` method, code what you want this tool to do.
 
 ### Running unit tests
-Run unit tests by running `mvn test`. 
- 
+
+Run unit tests by running `mvn test`.
+
 ### Running integration tests
+
 Before you run the integration tests (locally):
- 1. Make sure that you have access to the github orgs specified in [TestCommon.ORGS](https://github.com/salesforce/dockerfile-image-update/blob/master/dockerfile-image-update-itest/src/main/java/com/salesforce/dockerfileimageupdate/itest/tests/TestCommon.java#L33). You likely will need to change it to three
-    orgs where you have permissions to create repositories. 
- 2. Make sure you have `git_api_url=https://api.github.com` in `/dockerfile-image-update-itest/itest.env`, 
-    or set it to your internal GitHub Enterprise.
- 3. Make sure you have a secret file which contains the `git_api_token`. 
-    The token needs to have `delete_repo, repo` permissions. 
-    You can generate your token by going to [personal access tokens](https://github.com/settings/tokens/new) in GitHub. 
-    Once you have your token place it in a file: 
-    ```
-    echo git_api_token=[copy personal access token here] > ${HOME}/.dfiu-itest-token
-    ```   
- 4. Export the following environment variable to point to the file: 
-    ```
-    export user_itest_secrets_file_secret=${HOME}/.dfiu-itest-token
-    ```
- 5. Run integration tests by running 
-    ```
-    make itest-local-changes
-    ```
-    
+
+1. Make sure that you have access to the github orgs specified in
+   [TestCommon.ORGS](https://github.com/salesforce/dockerfile-image-update/blob/master/dockerfile-image-update-itest/src/main/java/com/salesforce/dockerfileimageupdate/itest/tests/TestCommon.java#L33).
+   You likely will need to change it to three orgs where you have permissions
+   to create repositories.
+1. Make sure you have `git_api_url=https://api.github.com` in `/dockerfile-image-update-itest/itest.env`,
+   or set it to your internal GitHub Enterprise.
+1. Make sure you have a secret file which contains the `git_api_token`.
+   The token needs to have `delete_repo, repo` permissions.
+   You can generate your token by going to [personal access tokens](https://github.com/settings/tokens/new)
+   in GitHub. Once you have your token place it in a file:
+
+   ```
+   echo git_api_token=[copy personal access token here] > ${HOME}/.dfiu-itest-token
+   ```
+
+1. Export the following environment variable to point to the file:
+
+   ```
+   export user_itest_secrets_file_secret=${HOME}/.dfiu-itest-token
+   ```
+
+1. Run integration tests by running
+
+   ```
+   make itest-local-changes
+   ```
+
 ### Release Process
 
 We currently use GitHub Actions and Releases. In order to collect dependency
@@ -199,11 +269,10 @@ to manually trigger the release process. For now, that looks like the following:
   and select the latest tag to associate with that release. Change the
   version to reflect the same version as the tag (`1.0.${NEW_VERSION}`).
   Ideally we'll automate this to run at the end of the triggered workflow.
-  
 
-Blogs / Slides
-==============
+# Blogs / Slides
 
 * [2018-03-13 Salesforce Engineering Blog - Open Sourcing Dockerfile Image Update](https://engineering.salesforce.com/open-sourcing-dockerfile-image-update-6400121c1a75)
 * [2018 SRECon 18 - Auto-Cascading Security Updates Through Docker Images](https://www.slideshare.net/AndreyFalko1/srecon18americas-lightning-talk-autocascading-security-updates-through-docker-images?qid=c659b92a-aa60-4ef1-942a-de7b4fb66ad2&v=&b=&from_search=1)
-* [2018-10-22 - Lyft Engineering Blog - The Challenges Behind Rolling Out Security Updates To Your Docker Images](https://eng.lyft.com/the-challenges-behind-rolling-out-security-updates-to-your-docker-images-86106de47ece)
+* [2018-10-22 - Lyft Engineering Blog -
+  The Challenges Behind Rolling Out Security Updates To Your Docker Images](https://eng.lyft.com/the-challenges-behind-rolling-out-security-updates-to-your-docker-images-86106de47ece)

--- a/README.md
+++ b/README.md
@@ -190,10 +190,12 @@ to manually trigger the release process. For now, that looks like the following:
 
 * PRs continually get updated with labels by [Pull Request Labeler](https://github.com/actions/labeler)
   and that helps set us up for nice release notes by [Release Drafter](https://github.com/release-drafter/release-drafter).
+
 * After PRs have been merged to the primary branch, go to the Actions tab
   and trigger the `Release new version` Workflow. This will build,
   integration test, deploy the latest version to Docker Hub and Maven
   Central, and tag that commit hash with the next semantic version.
+
 * Once that release has been tagged you can go to the draft release which
   is continually updated by [Release Drafter](https://github.com/release-drafter/release-drafter)
   and select the latest tag to associate with that release. Change the

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Before you run the integration tests (locally):
     make itest-local-changes
     ```
     
-#### Release Process
+### Release Process
 
 We currently use GitHub Actions and Releases. In order to collect dependency
 updates from dependabot and any other minor changes, we've switched to a process

--- a/README.md
+++ b/README.md
@@ -183,20 +183,22 @@ Before you run the integration tests (locally):
     ```
     
 #### Release Process
+
 We currently use GitHub Actions and Releases. In order to collect dependency
 updates from dependabot and any other minor changes, we've switched to a process
 to manually trigger the release process. For now, that looks like the following:
+
 * PRs continually get updated with labels by [Pull Request Labeler](https://github.com/actions/labeler)
   and that helps set us up for nice release notes by [Release Drafter](https://github.com/release-drafter/release-drafter).
-* After PRs have been merged to the primary branch, go to the Actions tab and 
-  trigger the `Release new version` Workflow. This will build, integration test, 
-  deploy the latest version to Docker Hub and Maven Central, and tag that commit 
-  hash with the next semantic version.
-* Once that release has been tagged you can go to the draft release which is 
-  continually updated by [Release Drafter](https://github.com/release-drafter/release-drafter)
-  and select the latest tag to associate with that release. Change the version to 
-  reflect the same version as the tag (`1.0.${NEW_VERSION}`). Ideally we'll automate
-  this to run at the end of the triggered workflow.
+* After PRs have been merged to the primary branch, go to the Actions tab
+  and trigger the `Release new version` Workflow. This will build,
+  integration test, deploy the latest version to Docker Hub and Maven
+  Central, and tag that commit hash with the next semantic version.
+* Once that release has been tagged you can go to the draft release which
+  is continually updated by [Release Drafter](https://github.com/release-drafter/release-drafter)
+  and select the latest tag to associate with that release. Change the
+  version to reflect the same version as the tag (`1.0.${NEW_VERSION}`).
+  Ideally we'll automate this to run at the end of the triggered workflow.
   
 
 Blogs / Slides


### PR DESCRIPTION
I'd like to resolve the problem of cutting releases that no one really cares about without adding a lot of extra effort. Here's a good illustration of the issue:
![image](https://user-images.githubusercontent.com/1042638/122651426-561ddb80-d0fe-11eb-8d38-ccafe1989f31.png)



* Allow labeler to run on PRs
* Move release to manual dispatch+CodeClimate PR fix 
  * Move release to manual action to collect dependency PRs before release
  * CodeClimate Test Reporter ID isn't a secret - open it for fork usage
      Ref: https://docs.codeclimate.com/docs/finding-your-test-coverage-token#should-i-keep-my-test-reporter-id-secret