### PR TITLE
Split image name if there are dots

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/search/GitHubImageSearchTermList.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/search/GitHubImageSearchTermList.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public class GitHubImageSearchTermList {
     /**
-     * We need to split out search terms to accomodate how GitHub code search works
+     * We need to split out search terms to accommodate how GitHub code search works
      * https://docs.github.com/en/github/searching-for-information-on-github/searching-code#considerations-for-code-search
      *
      * Essentially we'll split out any dashes in the registry domain and split out any url segments with dashes by
@@ -68,7 +68,17 @@ public class GitHubImageSearchTermList {
             state.finalizeCurrentTerm();
         }
         state.addToCurrentTerm("/");
-        state.addToCurrentTerm(finalImageSegment);
+        if (finalImageSegment.contains(".")) {
+            String[] finalSegments = finalImageSegment.split("\\.");
+            for (int index = 0; index < finalSegments.length; index++) {
+                state.addToCurrentTerm(finalSegments[index]);
+                if (index < finalSegments.length - 1) {
+                    state.finalizeCurrentTerm();
+                }
+            }
+        } else {
+            state.addToCurrentTerm(finalImageSegment);
+        }
     }
 
     /**

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/search/GitHubImageSearchTermListTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/search/GitHubImageSearchTermListTest.java
@@ -27,6 +27,8 @@ public class GitHubImageSearchTermListTest {
                 {"this-registry-has-dashes.some-company.with-dashes.io/rv-python-runtime", ImmutableList.of("FROM this", "registry", "has", "dashes.some", "company.with", "dashes.io/rv-python-runtime")},
                 {"this-registry-has-dashes.some-company.with-dashes.io/some-path/with-more-dashes/rv-python-runtime", ImmutableList.of("FROM this", "registry", "has", "dashes.some", "company.with", "dashes.io", "some-path", "with-more-dashes", "/rv-python-runtime")},
                 {"this-registry-has-dashes.some-company.with-dashes.io/somepath/with-more-dashes/rv-python-runtime", ImmutableList.of("FROM this", "registry", "has", "dashes.some", "company.with", "dashes.io/somepath", "with-more-dashes", "/rv-python-runtime")},
+                {"this-registry-has-dashes.some-company.with-dashes.io/somepath/with-more-dashes/rv-python-3.9-runtime", ImmutableList.of("FROM this", "registry", "has", "dashes.some", "company.with", "dashes.io/somepath", "with-more-dashes", "/rv-python-3", "9-runtime")},
+                {"this-registry-has-dashes.some-company.with-dashes.io/somepath/with-more-dashes/rv.python.3-9.runtime", ImmutableList.of("FROM this", "registry", "has", "dashes.some", "company.with", "dashes.io/somepath", "with-more-dashes", "/rv", "python", "3-9", "runtime")},
         };
     }
 


### PR DESCRIPTION
As in #212, mixing dots and dashes makes GitHub Code Search sad.
Since it's less likely to encounter dots than dashes in an image name,
and because we've covered previous segments, we'll split the image
name by dots.

Fixes #217 #245