### PR TITLE
Adding code climate command to developer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,12 +270,10 @@ to manually trigger the release process. For now, that looks like the following:
   version to reflect the same version as the tag (`1.0.${NEW_VERSION}`).
   Ideally we'll automate this to run at the end of the triggered workflow.
 
-
 ### Checking Code Climate Locally
 
-
-If you'd like to check [Code Climate](https://codeclimate.com/quality/) results locally you 
-can run the following:
+If you'd like to check [Code Climate](https://codeclimate.com/quality/) 
+results locally you can run the following:
 
 ```
 docker run --interactive --tty --rm \

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ to manually trigger the release process. For now, that looks like the following:
   and select the latest tag to associate with that release. Change the
   version to reflect the same version as the tag (`1.0.${NEW_VERSION}`).
   Ideally we'll automate this to run at the end of the triggered workflow.
-  
+
 ### Checking Code Climate Locally
 
 If you'd like to check [Code Climate](https://codeclimate.com/quality/) results locally you can run the following: 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,19 @@ to manually trigger the release process. For now, that looks like the following:
   and select the latest tag to associate with that release. Change the
   version to reflect the same version as the tag (`1.0.${NEW_VERSION}`).
   Ideally we'll automate this to run at the end of the triggered workflow.
+  
+### Checking Code Climate Locally
+
+If you'd like to check [Code Climate](https://codeclimate.com/quality/) results locally you can run the following: 
+
+```
+docker run --interactive --tty --rm \
+ --env CODECLIMATE_CODE="$(pwd)" \
+ --volume "$(pwd)":/code \
+ --volume /var/run/docker.sock:/var/run/docker.sock \
+ --volume /tmp/cc:/tmp/cc \
+ codeclimate/codeclimate analyze README.md
+```
 
 # Blogs / Slides
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ to manually trigger the release process. For now, that looks like the following:
 
 ### Checking Code Climate Locally
 
-If you'd like to check [Code Climate](https://codeclimate.com/quality/) 
+If you'd like to check [Code Climate](https://codeclimate.com/quality/)
 results locally you can run the following:
 
 ```

--- a/README.md
+++ b/README.md
@@ -270,9 +270,12 @@ to manually trigger the release process. For now, that looks like the following:
   version to reflect the same version as the tag (`1.0.${NEW_VERSION}`).
   Ideally we'll automate this to run at the end of the triggered workflow.
 
+
 ### Checking Code Climate Locally
 
-If you'd like to check [Code Climate](https://codeclimate.com/quality/) results locally you can run the following: 
+
+If you'd like to check [Code Climate](https://codeclimate.com/quality/) results locally you 
+can run the following:
 
 ```
 docker run --interactive --tty --rm \


### PR DESCRIPTION
Just taking the cmd you mentioned in the [merged PR](https://github.com/salesforce/dockerfile-image-update/pull/250) and adding it to the readme.