### PR TITLE
Workaround for the GitHub Search API limit

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
@@ -73,6 +73,8 @@ public class CommandLine {
                 .help("regex of repository names to exclude from pull request generation");
         parser.addArgument("-B")
                 .help("additional body text to include in pull requests");
+        parser.addArgument("-l", "--" + Constants.GIT_API_SEARCH_LIMIT)
+                .help("limit the search results for github api (default: 1000)");
         return parser;
     }
 

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
@@ -53,9 +53,14 @@ public class CommandLine {
     }
 
     static ArgumentParser getArgumentParser() {
-        ArgumentParser parser = ArgumentParsers.newFor("dockerfile-image-update").addHelp(true).build()
+        ArgumentParser parser =
+                ArgumentParsers.newFor("dockerfile-image-update").addHelp(true).build()
                 .description("Image Updates through Pull Request Automator");
 
+        parser.addArgument("-l", "--" + Constants.GIT_API_SEARCH_LIMIT)
+                .type(Integer.class)
+                .setDefault(1000)
+                .help("limit the search results for github api (default: 1000)");
         parser.addArgument("-o", "--" + Constants.GIT_ORG)
                 .help("search within specific organization (default: all of github)");
         /* Currently, because of argument passing reasons, you can only specify one branch. */
@@ -73,10 +78,6 @@ public class CommandLine {
                 .help("regex of repository names to exclude from pull request generation");
         parser.addArgument("-B")
                 .help("additional body text to include in pull requests");
-        parser.addArgument("-l", "--" + Constants.GIT_API_SEARCH_LIMIT)
-                .help("limit the search results for github api (default: 1000)")
-                .type(Integer.class)
-                .setDefault(1000);
         return parser;
     }
 

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
@@ -74,7 +74,9 @@ public class CommandLine {
         parser.addArgument("-B")
                 .help("additional body text to include in pull requests");
         parser.addArgument("-l", "--" + Constants.GIT_API_SEARCH_LIMIT)
-                .help("limit the search results for github api (default: 1000)");
+                .help("limit the search results for github api (default: 1000)")
+                .type(Integer.class)
+                .setDefault(1000);
         return parser;
     }
 

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -48,12 +48,18 @@ public class All implements ExecutableWithNamespace {
         Multimap<String, String> pathToDockerfilesInParentRepo = ArrayListMultimap.create();
 
         Set<Map.Entry<String, JsonElement>> imageToTagStore = parseStoreToImagesMap(ns.get(Constants.STORE));
+        Integer gitApiSearchLimit;
+        if (ns.get(Constants.GIT_API_SEARCH_LIMIT) == null || Integer.parseInt(ns.get(Constants.GIT_API_SEARCH_LIMIT)) > Constants.GIT_API_SEARCH_LIMIT_NUMBER) {
+            gitApiSearchLimit = Constants.GIT_API_SEARCH_LIMIT_NUMBER;
+        } else {
+            gitApiSearchLimit = Integer.parseInt(ns.get(Constants.GIT_API_SEARCH_LIMIT));
+        }
         for (Map.Entry<String, JsonElement> imageToTag : imageToTagStore) {
             String image = imageToTag.getKey();
             log.info("Repositories with image {} being forked.", image);
             imageToTagMap.put(image, imageToTag.getValue().getAsString());
             List<PagedSearchIterable<GHContent>> contentsWithImage =
-                    this.dockerfileGitHubUtil.findFilesWithImage(image, ns.get(Constants.GIT_ORG));
+                    this.dockerfileGitHubUtil.findFilesWithImage(image, ns.get(Constants.GIT_ORG), null, gitApiSearchLimit);
             for (int i = 0; i < contentsWithImage.size(); i++) {
                 forkRepositoriesFound(pathToDockerfilesInParentRepo,
                         imagesFoundInParentRepo, contentsWithImage.get(i), image);

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -51,7 +51,9 @@ public class All implements ExecutableWithNamespace {
         Integer gitApiSearchLimit = ns.get(Constants.GIT_API_SEARCH_LIMIT);
         List<IOException> exceptions = new ArrayList<>();
         Map<String, Boolean> orgsToIncludeInSearch = new HashMap<>();
-        orgsToIncludeInSearch.put(ns.get(Constants.GIT_ORG), true);
+        if (!ns.get(Constants.GIT_ORG).toString().isEmpty()) {
+            orgsToIncludeInSearch.put(ns.get(Constants.GIT_ORG), true);
+        }
         for (Map.Entry<String, JsonElement> imageToTag : imageToTagStore) {
             String image = imageToTag.getKey();
             log.info("Repositories with image {} being forked.", image);

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -51,9 +51,7 @@ public class All implements ExecutableWithNamespace {
         Integer gitApiSearchLimit = ns.get(Constants.GIT_API_SEARCH_LIMIT);
         List<IOException> exceptions = new ArrayList<>();
         Map<String, Boolean> orgsToIncludeInSearch = new HashMap<>();
-        if (!ns.get(Constants.GIT_ORG).toString().isEmpty()) {
-            orgsToIncludeInSearch.put(ns.get(Constants.GIT_ORG), true);
-        }
+        orgsToIncludeInSearch.put(ns.get(Constants.GIT_ORG), true);
         for (Map.Entry<String, JsonElement> imageToTag : imageToTagStore) {
             String image = imageToTag.getKey();
             log.info("Repositories with image {} being forked.", image);

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -58,15 +58,17 @@ public class All implements ExecutableWithNamespace {
             imageToTagMap.put(image, imageToTag.getValue().getAsString());
             Optional<List<PagedSearchIterable<GHContent>>> contentsWithImage =
                     this.dockerfileGitHubUtil.findFilesWithImage(image, orgsToIncludeInSearch, gitApiSearchLimit);
-            contentsWithImage.get().forEach(pagedSearchIterable -> {
-                try {
-                    forkRepositoriesFound(pathToDockerfilesInParentRepo,
-                            imagesFoundInParentRepo, pagedSearchIterable, image);
-                } catch (IOException e) {
-                    log.error(String.format("Error while creating a fork"));
-                    exceptions.add(e);
-                }
-            });
+            if (contentsWithImage.isPresent()) {
+                contentsWithImage.get().forEach(pagedSearchIterable -> {
+                    try {
+                        forkRepositoriesFound(pathToDockerfilesInParentRepo,
+                                imagesFoundInParentRepo, pagedSearchIterable, image);
+                    } catch (IOException e) {
+                        log.error("Error while creating a fork");
+                        exceptions.add(e);
+                    }
+                });
+            }
         }
 
         GHMyself currentUser = this.dockerfileGitHubUtil.getMyself();

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -51,7 +51,12 @@ public class All implements ExecutableWithNamespace {
         Integer gitApiSearchLimit = ns.get(Constants.GIT_API_SEARCH_LIMIT);
         List<IOException> exceptions = new ArrayList<>();
         Map<String, Boolean> orgsToIncludeInSearch = new HashMap<>();
-        orgsToIncludeInSearch.put(ns.get(Constants.GIT_ORG), true);
+        if (ns.get(Constants.GIT_ORG) != null) {
+            // If there is a Git org specified, that needs to be included in the search query. In
+            // the orgsToIncludeInSearch a true value associated with an org name ensures that
+            // the org gets included in the search query.
+            orgsToIncludeInSearch.put(ns.get(Constants.GIT_ORG), true);
+        }
         for (Map.Entry<String, JsonElement> imageToTag : imageToTagStore) {
             String image = imageToTag.getKey();
             log.info("Repositories with image {} being forked.", image);

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -52,10 +52,12 @@ public class All implements ExecutableWithNamespace {
             String image = imageToTag.getKey();
             log.info("Repositories with image {} being forked.", image);
             imageToTagMap.put(image, imageToTag.getValue().getAsString());
-            PagedSearchIterable<GHContent> contentsWithImage =
+            List<PagedSearchIterable<GHContent>> contentsWithImage =
                     this.dockerfileGitHubUtil.findFilesWithImage(image, ns.get(Constants.GIT_ORG));
-            forkRepositoriesFound(pathToDockerfilesInParentRepo,
-                    imagesFoundInParentRepo, contentsWithImage, image);
+            for (int i = 0; i < contentsWithImage.size(); i++) {
+                forkRepositoriesFound(pathToDockerfilesInParentRepo,
+                        imagesFoundInParentRepo, contentsWithImage.get(i), image);
+            }
         }
 
         GHMyself currentUser = this.dockerfileGitHubUtil.getMyself();

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
@@ -59,12 +59,7 @@ public class Parent implements ExecutableWithNamespace {
 
         log.info("Finding Dockerfiles with the given image...");
 
-        Integer gitApiSearchLimit;
-        if (ns.get(Constants.GIT_API_SEARCH_LIMIT) == null || Integer.parseInt(ns.get(Constants.GIT_API_SEARCH_LIMIT)) > Constants.GIT_API_SEARCH_LIMIT_NUMBER) {
-            gitApiSearchLimit = Constants.GIT_API_SEARCH_LIMIT_NUMBER;
-        } else {
-            gitApiSearchLimit = Integer.parseInt(ns.get(Constants.GIT_API_SEARCH_LIMIT));
-        }
+        Integer gitApiSearchLimit = ns.get(Constants.GIT_API_SEARCH_LIMIT);
         Optional<List<PagedSearchIterable<GHContent>>> contentsWithImage = dockerfileGitHubUtil.getGHContents(ns.get(Constants.GIT_ORG), img, gitApiSearchLimit);
         if (contentsWithImage.isPresent()) {
             List<PagedSearchIterable<GHContent>> contentsFoundWithImage = contentsWithImage.get();

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
@@ -34,4 +34,6 @@ public class Constants {
     public static final String GIT_PR_BODY = "B";
     public static final String GIT_ADDITIONAL_COMMIT_MESSAGE = "c";
     public static final String GIT_REPO_EXCLUDES = "excludes";
+    public static final String GIT_API_SEARCH_LIMIT = "git-api-search-limit";
+    public static final Integer GIT_API_SEARCH_LIMIT_NUMBER = 1000;
 }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
@@ -34,6 +34,5 @@ public class Constants {
     public static final String GIT_PR_BODY = "B";
     public static final String GIT_ADDITIONAL_COMMIT_MESSAGE = "c";
     public static final String GIT_REPO_EXCLUDES = "excludes";
-    public static final String GIT_API_SEARCH_LIMIT = "git-api-search-limit";
-    public static final Integer GIT_API_SEARCH_LIMIT_NUMBER = 1000;
+    public static final String GIT_API_SEARCH_LIMIT = "ghapisearchlimit";
 }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -407,7 +407,12 @@ public class DockerfileGitHubUtil {
             throws IOException, InterruptedException {
         Optional<List<PagedSearchIterable<GHContent>>> contentsWithImage = Optional.empty();
         Map<String, Boolean> orgsToIncludeInSearch = new HashMap<>();
-        orgsToIncludeInSearch.put(org, true);
+        if (org != null) {
+            // If there is a Git org specified, that needs to be included in the search query. In
+            // the orgsToIncludeInSearch a true value associated with an org name ensures that
+            // the org gets included in the search query.
+            orgsToIncludeInSearch.put(org, true);
+        }
         for (int i = 0; i < 5; i++) {
             contentsWithImage = findFilesWithImage(img, orgsToIncludeInSearch, gitApiSearchLimit);
             if (contentsWithImage

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -95,12 +95,14 @@ public class DockerfileGitHubUtil {
         if (!orgsToIncludeOrExclude.isEmpty()) {
             StringBuilder includeOrExcludeOrgsQuery = new StringBuilder();
             for (Map.Entry<String, Boolean> org : orgsToIncludeOrExclude.entrySet()){
-                if (org.getValue()) {
-                    log.info("Including the org {} in the search.", org.getKey());
-                    includeOrExcludeOrgsQuery.append(String.format("user:%s ", org.getKey()));
-                } else {
-                    log.info("Excluding the org {} from the search.", org.getKey());
-                    includeOrExcludeOrgsQuery.append(String.format("-org:%s ", org.getKey()));
+                if (org.getKey() != null) {
+                    if (org.getValue()) {
+                        log.info("Including the org {} in the search.", org.getKey());
+                        includeOrExcludeOrgsQuery.append(String.format("user:%s ", org.getKey()));
+                    } else {
+                        log.info("Excluding the org {} from the search.", org.getKey());
+                        includeOrExcludeOrgsQuery.append(String.format("-org:%s ", org.getKey()));
+                    }
                 }
             }
             search.q(includeOrExcludeOrgsQuery.toString());

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -117,12 +117,20 @@ public class DockerfileGitHubUtil {
         int totalCount = files.getTotalCount();
         log.info("Number of files found for {}: {}", image, totalCount);
         if (totalCount > gitApiSearchLimit
-                && orgsToIncludeOrExclude.size() == 1
-                && orgsToIncludeOrExclude.entrySet()
+            && orgsToIncludeOrExclude.size() == 1
+            && orgsToIncludeOrExclude
+                .entrySet()
                 .stream()
                 .findFirst()
                 .get()
-                .getValue()) {
+                .getKey() != null
+            && orgsToIncludeOrExclude
+                .entrySet()
+                .stream()
+                .findFirst()
+                .get()
+                .getValue()
+                ) {
             String orgName = orgsToIncludeOrExclude
                     .entrySet()
                     .stream()

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -118,7 +118,7 @@ public class DockerfileGitHubUtil {
         log.info("Number of files found for {}: {}", image, totalCount);
 
         Boolean includeOrExclude = false;
-        if (!orgsToIncludeOrExclude.isEmpty()) {
+        if (!orgsToIncludeOrExclude.isEmpty() && orgsToIncludeOrExclude.size() == 1) {
             for (Map.Entry<String, Boolean> org : orgsToIncludeOrExclude.entrySet()){
                 if (org.getKey() != null) {
                     includeOrExclude = org.getValue();

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -16,8 +16,8 @@ import com.salesforce.dockerfileimageupdate.repository.GitHub;
 import com.salesforce.dockerfileimageupdate.search.GitHubImageSearchTermList;
 import com.salesforce.dockerfileimageupdate.storage.GitHubJsonStore;
 import org.kohsuke.github.*;
-import org.slf4j.Logger;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -141,10 +141,10 @@ public class DockerfileGitHubUtil {
             log.warn("Number of search results for a single org {} is above {}! The GitHub Search API will only return around 1000 results - https://developer.github.com/v3/search/#about-the-search-api",
                     orgName, gitApiSearchLimit);
         } else if (totalCount > gitApiSearchLimit) {
-            log.info("The number of files returned is greater than the git API search limit" +
-                    " of {}. The orgs with the maximum number of hits will be recursively removed" +
-                    " to reduce the search space. For every org that is excluded, a separate " +
-                    "search will be performed specific to that org.", gitApiSearchLimit);
+            log.info("The number of files returned is greater than the git API search limit"
+                    + " of {}. The orgs with the maximum number of hits will be recursively removed"
+                    + " to reduce the search space. For every org that is excluded, a separate "
+                    + "search will be performed specific to that org.", gitApiSearchLimit);
             return getSearchResultsExcludingOrgWithMostHits(image, files, orgsToIncludeOrExclude, gitApiSearchLimit);
         }
         List<PagedSearchIterable<GHContent>> filesList = new ArrayList<>();

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -117,11 +117,12 @@ public class DockerfileGitHubUtil {
         int totalCount = files.getTotalCount();
         log.info("Number of files found for {}: {}", image, totalCount);
         if (totalCount > gitApiSearchLimit && orgsToIncludeOrExclude.size() == 1 && orgsToIncludeOrExclude.entrySet().stream().findFirst().get().getValue()) {
-            log.warn("Number of search results for a single org {} is above 1000! The GitHub Search API will only return around 1000 results - https://developer.github.com/v3/search/#about-the-search-api",
-                    orgsToIncludeOrExclude.entrySet().stream().findFirst().get().getKey());
-        }
-        else if (totalCount > gitApiSearchLimit) {
+            log.warn("Number of search results for a single org {} is above {}! The GitHub Search API will only return around 1000 results - https://developer.github.com/v3/search/#about-the-search-api",
+                    orgsToIncludeOrExclude.entrySet().stream().findFirst().get().getKey(), gitApiSearchLimit);
+        } else if (totalCount > gitApiSearchLimit) {
             return getSearchResultsExcludingOrgWithMostHits(image, files, orgsToIncludeOrExclude, gitApiSearchLimit);
+        } else{
+            log.warn("This is an unexpected path. Something went wrong while searching for files.");
         }
         filesList.add(files);
         return Optional.of(filesList);

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -116,16 +116,21 @@ public class DockerfileGitHubUtil {
         PagedSearchIterable<GHContent> files = search.list();
         int totalCount = files.getTotalCount();
         log.info("Number of files found for {}: {}", image, totalCount);
-
-        Boolean includeOrExclude = false;
-        if (!orgsToIncludeOrExclude.isEmpty() && orgsToIncludeOrExclude.size() == 1) {
-            for (Map.Entry<String, Boolean> org : orgsToIncludeOrExclude.entrySet()){
-                if (org.getKey() != null) {
-                    includeOrExclude = org.getValue();
-                }
-            }
-        }
-        if (totalCount > gitApiSearchLimit && orgsToIncludeOrExclude.size() == 1 && includeOrExclude) {
+        if (totalCount > gitApiSearchLimit
+            && orgsToIncludeOrExclude.size() == 1
+            && orgsToIncludeOrExclude
+                .entrySet()
+                .stream()
+                .findFirst()
+                .get()
+                .getKey() != null
+            && orgsToIncludeOrExclude
+                .entrySet()
+                .stream()
+                .findFirst()
+                .get()
+                .getValue()
+                ) {
             String orgName = orgsToIncludeOrExclude
                     .entrySet()
                     .stream()

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -116,6 +116,19 @@ public class DockerfileGitHubUtil {
         PagedSearchIterable<GHContent> files = search.list();
         int totalCount = files.getTotalCount();
         log.info("Number of files found for {}: {}", image, totalCount);
+        log.info("--Debug--");
+        log.info(String.valueOf(orgsToIncludeOrExclude
+                .entrySet()
+                .stream()
+                .findFirst()
+                .get()
+                .getKey() != null));
+        log.info(String.valueOf(orgsToIncludeOrExclude
+                .entrySet()
+                .stream()
+                .findFirst()
+                .get()
+                .getValue()));
         if (totalCount > gitApiSearchLimit
             && orgsToIncludeOrExclude.size() == 1
             && orgsToIncludeOrExclude
@@ -131,6 +144,7 @@ public class DockerfileGitHubUtil {
                 .get()
                 .getValue()
                 ) {
+            log.info("--Debug--");
             String orgName = orgsToIncludeOrExclude
                     .entrySet()
                     .stream()

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -93,17 +93,17 @@ public class DockerfileGitHubUtil {
         // https://github.com/github/linguist/issues/4566
         search.filename("Dockerfile");
         if (!orgsToIncludeOrExclude.isEmpty()) {
-            StringBuilder includeOrexcludeOrgsQuery = new StringBuilder();
+            StringBuilder includeOrExcludeOrgsQuery = new StringBuilder();
             for (Map.Entry<String, Boolean> org : orgsToIncludeOrExclude.entrySet()){
                 if (org.getValue()) {
                     log.info("Including the org {} in the search.", org.getKey());
-                    includeOrexcludeOrgsQuery.append(String.format("user:%s ", org.getKey()));
+                    includeOrExcludeOrgsQuery.append(String.format("user:%s ", org.getKey()));
                 } else {
                     log.info("Excluding the org {} from the search.", org.getKey());
-                    includeOrexcludeOrgsQuery.append(String.format("-org:%s ", org.getKey()));
+                    includeOrExcludeOrgsQuery.append(String.format("-org:%s ", org.getKey()));
                 }
             }
-            search.q(includeOrexcludeOrgsQuery.toString());
+            search.q(includeOrExcludeOrgsQuery.toString());
         }
         if (image.substring(image.lastIndexOf(' ') + 1).length() <= 1) {
             throw new IOException("Invalid image name.");

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -141,8 +141,6 @@ public class DockerfileGitHubUtil {
                     orgName, gitApiSearchLimit);
         } else if (totalCount > gitApiSearchLimit) {
             return getSearchResultsExcludingOrgWithMostHits(image, files, orgsToIncludeOrExclude, gitApiSearchLimit);
-        } else{
-            log.warn("This is an unexpected path. Something went wrong while searching for files.");
         }
         List<PagedSearchIterable<GHContent>> filesList = new ArrayList<>();
         filesList.add(files);

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -116,35 +116,16 @@ public class DockerfileGitHubUtil {
         PagedSearchIterable<GHContent> files = search.list();
         int totalCount = files.getTotalCount();
         log.info("Number of files found for {}: {}", image, totalCount);
-        log.info("--Debug--");
-        log.info(String.valueOf(orgsToIncludeOrExclude
-                .entrySet()
-                .stream()
-                .findFirst()
-                .get()
-                .getKey() != null));
-        log.info(String.valueOf(orgsToIncludeOrExclude
-                .entrySet()
-                .stream()
-                .findFirst()
-                .get()
-                .getValue()));
-        if (totalCount > gitApiSearchLimit
-            && orgsToIncludeOrExclude.size() == 1
-            && orgsToIncludeOrExclude
-                .entrySet()
-                .stream()
-                .findFirst()
-                .get()
-                .getKey() != null
-            && orgsToIncludeOrExclude
-                .entrySet()
-                .stream()
-                .findFirst()
-                .get()
-                .getValue()
-                ) {
-            log.info("--Debug--");
+
+        Boolean includeOrExclude = false;
+        if (!orgsToIncludeOrExclude.isEmpty()) {
+            for (Map.Entry<String, Boolean> org : orgsToIncludeOrExclude.entrySet()){
+                if (org.getKey() != null) {
+                    includeOrExclude = org.getValue();
+                }
+            }
+        }
+        if (totalCount > gitApiSearchLimit && orgsToIncludeOrExclude.size() == 1 && includeOrExclude) {
             String orgName = orgsToIncludeOrExclude
                     .entrySet()
                     .stream()

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -277,10 +277,7 @@ public class DockerfileGitHubUtilTest {
 
         PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
 
-        List<PagedSearchIterable<GHContent>> contentsWithImageList = new ArrayList<>();
-        contentsWithImageList.add(contentsWithImage);
-        contentsWithImageList.add(contentsWithImage);
-        contentsWithImageList.add(contentsWithImage);
+        List<PagedSearchIterable<GHContent>> contentsWithImageList = Arrays.asList(contentsWithImage, contentsWithImage, contentsWithImage);
         Optional<List<PagedSearchIterable<GHContent>>> optionalContentsWithImageList = Optional.of(contentsWithImageList);
 
         when(contentsWithImage.toList()).thenReturn(ghContentList);
@@ -638,8 +635,7 @@ public class DockerfileGitHubUtilTest {
         GHContent content3 = mock(GHContent.class);
 
         PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
-        List<PagedSearchIterable<GHContent>> contentsWithImageList = new ArrayList<>();
-        contentsWithImageList.add(contentsWithImage);
+        List<PagedSearchIterable<GHContent>> contentsWithImageList = Collections.singletonList(contentsWithImage);
         Optional<List<PagedSearchIterable<GHContent>>> optionalContentsWithImageList = Optional.of(contentsWithImageList);
         when(contentsWithImage.getTotalCount()).thenReturn(3);
 
@@ -658,8 +654,7 @@ public class DockerfileGitHubUtilTest {
     public void testGHContentsNoOutput() throws Exception {
 
         PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
-        List<PagedSearchIterable<GHContent>> contentsWithImageList = new ArrayList<>();
-        contentsWithImageList.add(contentsWithImage);
+        List<PagedSearchIterable<GHContent>> contentsWithImageList = Collections.singletonList(contentsWithImage);
         Optional<List<PagedSearchIterable<GHContent>>> optionalContentsWithImageList = Optional.of(contentsWithImageList);
         when(contentsWithImage.getTotalCount()).thenReturn(0);
 

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -289,6 +289,7 @@ public class DockerfileGitHubUtilTest {
 
         dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
         Map<String, Boolean> orgsToIncludeOrExclude = new HashMap<>();
+        orgsToIncludeOrExclude.put(null, true);
 
         dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
         when(dockerfileGitHubUtil.getOrgNameWithMaximumHits(contentsWithImage)).thenReturn("org-1", "org-2", "org-3");

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -18,7 +18,14 @@ import org.testng.annotations.Test;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 
 import static com.salesforce.dockerfileimageupdate.model.PullRequestInfo.DEFAULT_TITLE;
 import static org.mockito.Matchers.*;
@@ -224,9 +231,8 @@ public class DockerfileGitHubUtilTest {
         when(gitHubUtil.startSearch()).thenReturn(ghContentSearchBuilder);
 
         dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
-        Map<String, Boolean> orgs = new HashMap<>();
-        orgs.put(org, true);
-        dockerfileGitHubUtil.findFilesWithImage(query, orgs,1000);
+        Map<String, Boolean> orgs = Collections.unmodifiableMap(Collections.singletonMap(org, true));
+        dockerfileGitHubUtil.findFilesWithImage(query, orgs, 1000);
     }
 
     @Test
@@ -244,9 +250,52 @@ public class DockerfileGitHubUtilTest {
         when(gitHubUtil.startSearch()).thenReturn(ghContentSearchBuilder);
 
         dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
-        Map<String, Boolean> orgs = new HashMap<>();
-        orgs.put("test", true);
+        Map<String, Boolean> orgs = Collections.unmodifiableMap(Collections.singletonMap("test", true));
         assertEquals(dockerfileGitHubUtil.findFilesWithImage("test", orgs, 1000), optionalContentsWithImageList);
+    }
+
+    @Test
+    public void testFindFilesWithMoreThan1000Results() throws Exception {
+        gitHubUtil = mock(GitHubUtil.class);
+        GHContentSearchBuilder ghContentSearchBuilder = mock(GHContentSearchBuilder.class);
+
+        GHRepository contentRepo1 = mock(GHRepository.class);
+        when(contentRepo1.getOwnerName()).thenReturn("org-1");
+        GHRepository contentRepo2 = mock(GHRepository.class);
+        when(contentRepo2.getOwnerName()).thenReturn("org-2");
+        GHRepository contentRepo3 = mock(GHRepository.class);
+        when(contentRepo3.getOwnerName()).thenReturn("org-3");
+
+
+        GHContent content1 = mock(GHContent.class);
+        when(content1.getOwner()).thenReturn(contentRepo1);
+        GHContent content2 = mock(GHContent.class);
+        when(content2.getOwner()).thenReturn(contentRepo2);
+        GHContent content3 = mock(GHContent.class);
+        when(content3.getOwner()).thenReturn(contentRepo3);
+        List<GHContent> ghContentList = Arrays.asList(content1, content2, content3);
+
+        PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
+
+        List<PagedSearchIterable<GHContent>> contentsWithImageList = new ArrayList<>();
+        contentsWithImageList.add(contentsWithImage);
+        contentsWithImageList.add(contentsWithImage);
+        contentsWithImageList.add(contentsWithImage);
+        Optional<List<PagedSearchIterable<GHContent>>> optionalContentsWithImageList = Optional.of(contentsWithImageList);
+
+        when(contentsWithImage.toList()).thenReturn(ghContentList);
+
+        //org-1 has 1001 matches, org-2 1000 matches and org-3 1000 matches
+        when(contentsWithImage.getTotalCount()).thenReturn(3001, 1001, 2000, 1000, 1000);
+        when(ghContentSearchBuilder.list()).thenReturn(contentsWithImage);
+        when(gitHubUtil.startSearch()).thenReturn(ghContentSearchBuilder);
+
+        dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
+        Map<String, Boolean> orgsToIncludeOrExclude = new HashMap<>();
+
+        dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
+        when(dockerfileGitHubUtil.getOrgNameWithMaximumHits(contentsWithImage)).thenReturn("org-1", "org-2", "org-3");
+        assertEquals(dockerfileGitHubUtil.findFilesWithImage("test", orgsToIncludeOrExclude, 1000), optionalContentsWithImageList);
     }
 
     @Test
@@ -270,10 +319,7 @@ public class DockerfileGitHubUtilTest {
         when(content3.getOwner()).thenReturn(contentRepo3);
         PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
 
-        List<GHContent> ghContentList = new ArrayList<>();
-        ghContentList.add(content1);
-        ghContentList.add(content2);
-        ghContentList.add(content3);
+        List<GHContent> ghContentList = Arrays.asList(content1, content2, content3);
 
         when(contentsWithImage.toList()).thenReturn(ghContentList);
 
@@ -306,10 +352,7 @@ public class DockerfileGitHubUtilTest {
         when(content3.getOwner()).thenReturn(contentRepo3);
         PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
 
-        List<GHContent> ghContentList = new ArrayList<>();
-        ghContentList.add(content1);
-        ghContentList.add(content2);
-        ghContentList.add(content3);
+        List<GHContent> ghContentList = Arrays.asList(content1, content2, content3);
 
         when(contentsWithImage.toList()).thenReturn(ghContentList);
 
@@ -604,8 +647,7 @@ public class DockerfileGitHubUtilTest {
         when(contentsWithImageIterator.hasNext()).thenReturn(true, true, true, false);
         when(contentsWithImageIterator.next()).thenReturn(content1, content2, content3, null);
         when(contentsWithImage.iterator()).thenReturn(contentsWithImageIterator);
-        Map<String, Boolean> orgs = new HashMap<>();
-        orgs.put("org", true);
+        Map<String, Boolean> orgs = Collections.unmodifiableMap(Collections.singletonMap("org", true));
         when(dockerfileGitHubUtil.findFilesWithImage(anyString(), eq(orgs), anyInt())).thenReturn(optionalContentsWithImageList);
         when(dockerfileGitHubUtil.getGHContents("org", "image", 1000)).thenCallRealMethod();
 
@@ -624,8 +666,7 @@ public class DockerfileGitHubUtilTest {
         GitHubUtil gitHubUtil = mock(GitHubUtil.class);
         DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
         when(dockerfileGitHubUtil.getGitHubUtil()).thenReturn(gitHubUtil);
-        Map<String, Boolean> orgs = new HashMap<>();
-        orgs.put("org", true);
+        Map<String, Boolean> orgs = Collections.unmodifiableMap(Collections.singletonMap("org", true));
         when(dockerfileGitHubUtil.findFilesWithImage(anyString(), eq(orgs), anyInt())).thenReturn(optionalContentsWithImageList);
         when(dockerfileGitHubUtil.getGHContents("org", "image", 1000)).thenCallRealMethod();
 


### PR DESCRIPTION
Currently, due to a GIT API search limit of 1000, DFIU can only send PRs to up to 1000 downstream repos when a new version for a base image is available. With this change, if the number of downstream repos consuming a base image is more than 1000, the Git org with the most number of consumers is excluded from the search space. DFIU is run separately on that individual org while another search is executed while excluding that org. This process is repeated, by adding orgs recursively with the most number of consumers to the exclude list to reduce the search space till the resulting number of consumers is less than 1000. For each of the orgs that are added to the exclusion list, DFIU is run individually on each of those orgs.