### PR TITLE
Add new flag to parent

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
@@ -78,6 +78,10 @@ public class CommandLine {
                 .help("regex of repository names to exclude from pull request generation");
         parser.addArgument("-B")
                 .help("additional body text to include in pull requests");
+        parser.addArgument("-s")
+                .type(Boolean.class)
+                .setDefault(false)
+                .help("Only update image tag store. Skip creating PRs");
         return parser;
     }
 

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
@@ -78,7 +78,7 @@ public class CommandLine {
                 .help("regex of repository names to exclude from pull request generation");
         parser.addArgument("-B")
                 .help("additional body text to include in pull requests");
-        parser.addArgument("-s")
+        parser.addArgument("-s", "--" + Constants.SKIP_PR_CREATION)
                 .type(Boolean.class)
                 .setDefault(false)
                 .help("Only update image tag store. Skip creating PRs");

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
@@ -52,7 +52,7 @@ public class Parent implements ExecutableWithNamespace {
 
         if (ns.get(Constants.SKIP_PR_CREATION)) {
             log.info(String.format("Since the flag %s is set to True, the PR creation steps will " +
-                    "be skipped. ", ns.get(Constants.SKIP_PR_CREATION)));
+                    "be skipped. ", Constants.SKIP_PR_CREATION));
             System.exit(0);
         }
         GitHubPullRequestSender pullRequestSender =

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
@@ -50,6 +50,11 @@ public class Parent implements ExecutableWithNamespace {
         log.info("Updating store...");
         this.dockerfileGitHubUtil.getGitHubJsonStore(ns.get(Constants.STORE)).updateStore(img, tag);
 
+        if (ns.get(Constants.SKIP_PR_CREATION)) {
+            log.info(String.format("Since the flag %s is set to True, the PR creation steps will " +
+                    "be skipped. ", ns.get(Constants.SKIP_PR_CREATION)));
+            System.exit(0);
+        }
         GitHubPullRequestSender pullRequestSender =
                 new GitHubPullRequestSender(dockerfileGitHubUtil, new ForkableRepoValidator(dockerfileGitHubUtil),
                         ns.get(Constants.GIT_REPO_EXCLUDES));

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
@@ -51,9 +51,9 @@ public class Parent implements ExecutableWithNamespace {
         this.dockerfileGitHubUtil.getGitHubJsonStore(ns.get(Constants.STORE)).updateStore(img, tag);
 
         if (ns.get(Constants.SKIP_PR_CREATION)) {
-            log.info(String.format("Since the flag %s is set to True, the PR creation steps will " +
-                    "be skipped. ", Constants.SKIP_PR_CREATION));
-            System.exit(0);
+            log.info("Since the flag {} is set to True, the PR creation steps will "
+                    + "be skipped.", Constants.SKIP_PR_CREATION);
+            return;
         }
         GitHubPullRequestSender pullRequestSender =
                 new GitHubPullRequestSender(dockerfileGitHubUtil, new ForkableRepoValidator(dockerfileGitHubUtil),

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
@@ -35,4 +35,6 @@ public class Constants {
     public static final String GIT_ADDITIONAL_COMMIT_MESSAGE = "c";
     public static final String GIT_REPO_EXCLUDES = "excludes";
     public static final String GIT_API_SEARCH_LIMIT = "ghapisearchlimit";
+    public static final String SKIP_PR_CREATION = "skipprcreation";
+
 }


### PR DESCRIPTION
This PR adds a new flag to the parent command that allows us to skip the PR creation operations. If this flag is set to "true", DFIU will only update the image tag store and exit without creating PRs to any of the downstream repos. If the flag is set to "false", DFIU continues behaving the same way it does now. By default, the flag is set to false.
