### PR TITLE
Revert "Bump nexus-staging-maven-plugin from 1.6.10 to 1.6.11 in /dockerfile-image-update"

### DIFF
--- a/dockerfile-image-update/pom.xml
+++ b/dockerfile-image-update/pom.xml
@@ -230,7 +230,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.11</version>
+                        <version>1.6.10</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>


### PR DESCRIPTION
Reverts salesforce/dockerfile-image-update#312

Our releases are blocked due to:
```
Error:  Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.11:deploy (injected-nexus-deploy) on project dockerfile-image-update: Execution injected-nexus-deploy of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.11:deploy failed: An API incompatibility was encountered while executing org.sonatype.plugins:nexus-staging-maven-plugin:1.6.11:deploy: java.lang.IllegalAccessError: class com.sonatype.nexus.staging.client.internal.StagingWorkflowV3ServiceImpl tried to access method 'void com.google.common.base.Stopwatch.<init>()' (com.sonatype.nexus.staging.client.internal.StagingWorkflowV3ServiceImpl and com.google.common.base.Stopwatch are in unnamed module of loader org.codehaus.plexus.classworlds.realm.ClassRealm @6724cdec)
Error:  -----------------------------------------------------
Error:  realm =    extension>org.sonatype.plugins:nexus-staging-maven-plugin:1.6.11
Error:  strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
Error:  urls[0] = file:/root/.m2/repository/org/sonatype/plugins/nexus-staging-maven-plugin/1.6.11/nexus-staging-maven-plugin-1.6.11.jar
[snip]...[/snip]
Error:  urls[48] = file:/root/.m2/repository/ch/qos/logback/logback-classic/1.2.10/logback-classic-1.2.10.jar
Error:  Number of foreign imports: 1
Error:  import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
Error:  
Error:  -----------------------------------------------------
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginContainerException
```

Due to difficultly with reproducing the error locally, will try to back this change out to see if we can do a release.