### PR TITLE
Revert "Bump nexus-staging-maven-plugin from 1.6.8 to 1.6.10 in /dockerfile-image-update"

### DIFF
--- a/dockerfile-image-update/pom.xml
+++ b/dockerfile-image-update/pom.xml
@@ -230,7 +230,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.10</version>
+                        <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>


### PR DESCRIPTION
Reverts salesforce/dockerfile-image-update#309

Walking further back due to: https://github.com/salesforce/dockerfile-image-update/pull/313#issue-1146216500

Error this time around is:
```
Error:  Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.10:deploy (injected-nexus-deploy) on project dockerfile-image-update: Execution injected-nexus-deploy of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.10:deploy failed: Nexus connection problem to URL [https://s01.oss.sonatype.org/ ]: XPP3 pull parser library not present. Specify another driver. For example: new XStream(new DomDriver()): org.xmlpull.mxp1.MXParser -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
```