### PR TITLE
Catch exceptions while finding files with image

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -45,6 +45,7 @@ public class All implements ExecutableWithNamespace {
             // the org gets included in the search query.
             orgsToIncludeInSearch.put(ns.get(Constants.GIT_ORG), true);
         }
+        List<String> imagesThatCouldNotBeProcessed = new ArrayList<>();
         for (Map.Entry<String, JsonElement> imageToTag : imageToTagStore) {
             String image = imageToTag.getKey();
             String tag = imageToTag.getValue().getAsString();
@@ -66,8 +67,11 @@ public class All implements ExecutableWithNamespace {
                         log.error("Could not send pull request.");
                     }
                 });
+            } else {
+                imagesThatCouldNotBeProcessed.add(image);
             }
         }
+        log.info("The list of images for which a PR could not be created are: {}", imagesThatCouldNotBeProcessed);
     }
 
     protected void loadDockerfileGithubUtil(DockerfileGitHubUtil _dockerfileGitHubUtil) {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -71,7 +71,7 @@ public class All implements ExecutableWithNamespace {
                 imagesThatCouldNotBeProcessed.add(image);
             }
         }
-        log.info("The list of images for which a PR could not be created are: {}", imagesThatCouldNotBeProcessed);
+        log.warn("The list of images for which a PR could not be created are: {}", imagesThatCouldNotBeProcessed);
     }
 
     protected void loadDockerfileGithubUtil(DockerfileGitHubUtil _dockerfileGitHubUtil) {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -15,6 +15,7 @@ import com.salesforce.dockerfileimageupdate.process.*;
 import com.salesforce.dockerfileimageupdate.subcommands.ExecutableWithNamespace;
 import com.salesforce.dockerfileimageupdate.utils.Constants;
 import com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil;
+import com.salesforce.dockerfileimageupdate.utils.ProcessingErrors;
 import com.salesforce.dockerfileimageupdate.utils.PullRequests;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.kohsuke.github.*;
@@ -23,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @SubCommand(help="updates all repositories' Dockerfiles",
         requiredParams = {Constants.STORE})
@@ -45,33 +47,62 @@ public class All implements ExecutableWithNamespace {
             // the org gets included in the search query.
             orgsToIncludeInSearch.put(ns.get(Constants.GIT_ORG), true);
         }
-        List<String> imagesThatCouldNotBeProcessed = new ArrayList<>();
+        List<ProcessingErrors> imagesThatCouldNotBeProcessed = new LinkedList<>();
+        AtomicInteger numberOfImagesToProcess = new AtomicInteger();
+        AtomicInteger numberOfImagesFailedToProcess = new AtomicInteger();
         for (Map.Entry<String, JsonElement> imageToTag : imageToTagStore) {
+            numberOfImagesToProcess.getAndIncrement();
             String image = imageToTag.getKey();
             String tag = imageToTag.getValue().getAsString();
-            PullRequests pullRequests = getPullRequests();
-            GitHubPullRequestSender pullRequestSender = getPullRequestSender(dockerfileGitHubUtil, ns);
-            GitForkBranch gitForkBranch = getGitForkBranch(image, tag, ns);
+            try {
+                PullRequests pullRequests = getPullRequests();
+                GitHubPullRequestSender pullRequestSender = getPullRequestSender(dockerfileGitHubUtil, ns);
+                GitForkBranch gitForkBranch = getGitForkBranch(image, tag, ns);
 
-            log.info("Finding Dockerfiles with the image name {}...", image);
+                log.info("Finding Dockerfiles with the image name {}...", image);
 
-            Optional<List<PagedSearchIterable<GHContent>>> contentsWithImage =
-                    this.dockerfileGitHubUtil.findFilesWithImage(image, orgsToIncludeInSearch, gitApiSearchLimit);
+                Optional<List<PagedSearchIterable<GHContent>>> contentsWithImage =
+                        this.dockerfileGitHubUtil.findFilesWithImage(image, orgsToIncludeInSearch, gitApiSearchLimit);
 
-            if (contentsWithImage.isPresent()) {
-                contentsWithImage.get().forEach(pagedSearchIterable -> {
-                    try {
-                        pullRequests.prepareToCreate(ns, pullRequestSender,
-                                pagedSearchIterable, gitForkBranch, dockerfileGitHubUtil);
-                    } catch (IOException e) {
-                        log.error("Could not send pull request.");
-                    }
-                });
-            } else {
-                imagesThatCouldNotBeProcessed.add(image);
+                if (contentsWithImage.isPresent()) {
+                    contentsWithImage.get().forEach(pagedSearchIterable -> {
+                        try {
+                            pullRequests.prepareToCreate(ns, pullRequestSender,
+                                    pagedSearchIterable, gitForkBranch, dockerfileGitHubUtil);
+                        } catch (IOException e) {
+                            log.error("Could not send pull request for image {}.", image);
+                            processErrors(image, tag, e, imagesThatCouldNotBeProcessed, numberOfImagesFailedToProcess);
+                        }
+                    });
+                }
+            } catch (GHException | HttpException e){
+                log.error("Could not perform Github search for the image {}. Trying to proceed...", image);
+                processErrors(image, tag, e, imagesThatCouldNotBeProcessed, numberOfImagesFailedToProcess);
             }
         }
-        log.warn("The list of images for which a PR could not be created are: {}", imagesThatCouldNotBeProcessed);
+        printSummary(imagesThatCouldNotBeProcessed, numberOfImagesToProcess, numberOfImagesFailedToProcess);
+    }
+
+    protected void printSummary(List<ProcessingErrors> imagesThatCouldNotBeProcessed, AtomicInteger numberOfImagesToProcess, AtomicInteger numberOfImagesFailedToProcess) {
+        AtomicInteger numberOfImagesSuccessfullyProcessed = new AtomicInteger(numberOfImagesToProcess.get() - numberOfImagesFailedToProcess.get());
+        log.warn("The total number of images to process from image tag store: {}", numberOfImagesToProcess.get());
+        log.warn("The total number of images that were successfully processed: {}", numberOfImagesSuccessfullyProcessed.get());
+        log.warn("The total number of images that failed to be processed: {}. The following list shows the images that could not be processed.", numberOfImagesFailedToProcess.get());
+        imagesThatCouldNotBeProcessed.forEach(imageThatCouldNotBeProcessed -> {
+                if (imageThatCouldNotBeProcessed.getFailure().isPresent()) {
+                    log.warn("Image: {}, Exception: {}", imageThatCouldNotBeProcessed.getImageNameAndTag(), imageThatCouldNotBeProcessed.getFailure());
+                } else {
+                    log.warn("Image: {}, Exception: {}", imageThatCouldNotBeProcessed.getImageNameAndTag(), "Failure reason not known.");
+                }
+            }
+        );
+    }
+
+    protected void processErrors(String image, String tag, Exception e, List<ProcessingErrors> imagesThatCouldNotBeProcessed, AtomicInteger numberOfImagesFailedToProcess) {
+        String imageNameAndTag = image + ":" + tag;
+        ProcessingErrors processingErrors = new ProcessingErrors(imageNameAndTag, Optional.of(e));
+        imagesThatCouldNotBeProcessed.add(processingErrors);
+        numberOfImagesFailedToProcess.getAndIncrement();
     }
 
     protected void loadDockerfileGithubUtil(DockerfileGitHubUtil _dockerfileGitHubUtil) {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -117,19 +117,19 @@ public class DockerfileGitHubUtil {
         int totalCount = files.getTotalCount();
         log.info("Number of files found for {}: {}", image, totalCount);
         if (totalCount > gitApiSearchLimit
-                && orgsToIncludeOrExclude.size() == 1
-                && orgsToIncludeOrExclude
-                .entrySet()
-                .stream()
-                .findFirst()
-                .get()
-                .getKey() != null
-                && orgsToIncludeOrExclude
-                .entrySet()
-                .stream()
-                .findFirst()
-                .get()
-                .getValue()
+            && orgsToIncludeOrExclude.size() == 1
+            && orgsToIncludeOrExclude
+               .entrySet()
+               .stream()
+               .findFirst()
+               .get()
+               .getKey() != null
+            && orgsToIncludeOrExclude
+               .entrySet()
+               .stream()
+               .findFirst()
+               .get()
+               .getValue()
         ) {
             String orgName = orgsToIncludeOrExclude
                     .entrySet()

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -110,45 +110,50 @@ public class DockerfileGitHubUtil {
         if (image.substring(image.lastIndexOf(' ') + 1).length() <= 1) {
             throw new IOException("Invalid image name.");
         }
-        List<String> terms = GitHubImageSearchTermList.getSearchTerms(image);
-        log.info("Searching for {} with terms: {}", image, terms);
-        terms.forEach(search::q);
-        PagedSearchIterable<GHContent> files = search.list();
-        int totalCount = files.getTotalCount();
-        log.info("Number of files found for {}: {}", image, totalCount);
-        if (totalCount > gitApiSearchLimit
-            && orgsToIncludeOrExclude.size() == 1
-            && orgsToIncludeOrExclude
-                .entrySet()
-                .stream()
-                .findFirst()
-                .get()
-                .getKey() != null
-            && orgsToIncludeOrExclude
-                .entrySet()
-                .stream()
-                .findFirst()
-                .get()
-                .getValue()
-                ) {
-            String orgName = orgsToIncludeOrExclude
+        List<PagedSearchIterable<GHContent>> filesList = new ArrayList<>();
+        try {
+            List<String> terms = GitHubImageSearchTermList.getSearchTerms(image);
+            log.info("Searching for {} with terms: {}", image, terms);
+            terms.forEach(search::q);
+            PagedSearchIterable<GHContent> files = search.list();
+            int totalCount = files.getTotalCount();
+            log.info("Number of files found for {}: {}", image, totalCount);
+            if (totalCount > gitApiSearchLimit
+                    && orgsToIncludeOrExclude.size() == 1
+                    && orgsToIncludeOrExclude
                     .entrySet()
                     .stream()
                     .findFirst()
                     .get()
-                    .getKey();
-            log.warn("Number of search results for a single org {} is above {}! The GitHub Search API will only return around 1000 results - https://developer.github.com/v3/search/#about-the-search-api",
-                    orgName, gitApiSearchLimit);
-        } else if (totalCount > gitApiSearchLimit) {
-            log.info("The number of files returned is greater than the git API search limit"
-                    + " of {}. The orgs with the maximum number of hits will be recursively removed"
-                    + " to reduce the search space. For every org that is excluded, a separate "
-                    + "search will be performed specific to that org.", gitApiSearchLimit);
-            return getSearchResultsExcludingOrgWithMostHits(image, files, orgsToIncludeOrExclude, gitApiSearchLimit);
+                    .getKey() != null
+                    && orgsToIncludeOrExclude
+                    .entrySet()
+                    .stream()
+                    .findFirst()
+                    .get()
+                    .getValue()
+            ) {
+                String orgName = orgsToIncludeOrExclude
+                        .entrySet()
+                        .stream()
+                        .findFirst()
+                        .get()
+                        .getKey();
+                log.warn("Number of search results for a single org {} is above {}! The GitHub Search API will only return around 1000 results - https://developer.github.com/v3/search/#about-the-search-api",
+                        orgName, gitApiSearchLimit);
+            } else if (totalCount > gitApiSearchLimit) {
+                log.info("The number of files returned is greater than the git API search limit"
+                        + " of {}. The orgs with the maximum number of hits will be recursively removed"
+                        + " to reduce the search space. For every org that is excluded, a separate "
+                        + "search will be performed specific to that org.", gitApiSearchLimit);
+                return getSearchResultsExcludingOrgWithMostHits(image, files, orgsToIncludeOrExclude, gitApiSearchLimit);
+            }
+            filesList.add(files);
+            return Optional.of(filesList);
+        } catch (GHException e) {
+            log.warn("Could not perform Github search for the image {}. Trying to proceed... exception: {}", image, e.getMessage());
         }
-        List<PagedSearchIterable<GHContent>> filesList = new ArrayList<>();
-        filesList.add(files);
-        return Optional.of(filesList);
+        return Optional.empty();
     }
 
     protected String getOrgNameWithMaximumHits(PagedSearchIterable<GHContent> files) throws IOException {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -110,7 +110,6 @@ public class DockerfileGitHubUtil {
         if (image.substring(image.lastIndexOf(' ') + 1).length() <= 1) {
             throw new IOException("Invalid image name.");
         }
-        List<PagedSearchIterable<GHContent>> filesList = new ArrayList<>();
         try {
             List<String> terms = GitHubImageSearchTermList.getSearchTerms(image);
             log.info("Searching for {} with terms: {}", image, terms);
@@ -148,12 +147,13 @@ public class DockerfileGitHubUtil {
                         + "search will be performed specific to that org.", gitApiSearchLimit);
                 return getSearchResultsExcludingOrgWithMostHits(image, files, orgsToIncludeOrExclude, gitApiSearchLimit);
             }
+            List<PagedSearchIterable<GHContent>> filesList = new ArrayList<>();
             filesList.add(files);
             return Optional.of(filesList);
-        } catch (GHException e) {
-            log.warn("Could not perform Github search for the image {}. Trying to proceed... exception: {}", image, e.getMessage());
+        } catch (GHException | HttpException e) {
+            log.error("Could not perform Github search for the image {}. Trying to proceed...q", image, e);
+            return Optional.empty();
         }
-        return Optional.empty();
     }
 
     protected String getOrgNameWithMaximumHits(PagedSearchIterable<GHContent> files) throws IOException {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/ProcessingErrors.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/ProcessingErrors.java
@@ -1,0 +1,21 @@
+package com.salesforce.dockerfileimageupdate.utils;
+
+import java.util.Optional;
+
+public class ProcessingErrors {
+    private final String imageNameAndTag;
+    private final Optional<Exception> failure;
+
+    public ProcessingErrors(String imageNameAndTag, Optional<Exception> failure) {
+        this.imageNameAndTag = imageNameAndTag;
+        this.failure = failure;
+    }
+
+    public String getImageNameAndTag() {
+        return imageNameAndTag;
+    }
+
+    public Optional<Exception> getFailure() {
+        return failure;
+    }
+}

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/AllTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/AllTest.java
@@ -75,8 +75,8 @@ public class AllTest {
         verify(all, times(1)).getPullRequests();
         verify(pullRequests, times(1)).prepareToCreate(ns, pullRequestSender,
                 contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
-        verify(all, times(0)).processErrors(anyString(), anyString(), any(), anyList(), any());
-        verify(all, times(1)).printSummary(anyList(), any(), any());
+        verify(all, times(0)).processErrors(anyString(), anyString(), any(), anyList());
+        verify(all, times(1)).printSummary(anyList(), any());
     }
 
     @Test
@@ -121,8 +121,8 @@ public class AllTest {
         verify(all, times(1)).getPullRequests();
         verify(pullRequests, times(0)).prepareToCreate(ns, pullRequestSender,
                 contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
-        verify(all, times(0)).processErrors(anyString(), anyString(), any(), anyList(), any());
-        verify(all, times(1)).printSummary(anyList(), any(), any());
+        verify(all, times(0)).processErrors(anyString(), anyString(), any(), anyList());
+        verify(all, times(1)).printSummary(anyList(), any());
     }
 
     @Test
@@ -166,8 +166,8 @@ public class AllTest {
         verify(all, times(1)).getPullRequests();
         verify(pullRequests, times(0)).prepareToCreate(ns, pullRequestSender,
                 contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
-        verify(all, times(1)).processErrors(anyString(), anyString(), any(), anyList(), any());
-        verify(all, times(1)).printSummary(anyList(), any(), any());
+        verify(all, times(1)).processErrors(anyString(), anyString(), any(), anyList());
+        verify(all, times(1)).printSummary(anyList(), any());
     }
 
     @Test
@@ -213,8 +213,8 @@ public class AllTest {
         verify(all, times(1)).getPullRequests();
         verify(pullRequests, times(1)).prepareToCreate(ns, pullRequestSender,
                 contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
-        verify(all, times(1)).processErrors(anyString(), anyString(), any(), anyList(), any());
-        verify(all, times(1)).printSummary(anyList(), any(), any());
+        verify(all, times(1)).processErrors(anyString(), anyString(), any(), anyList());
+        verify(all, times(1)).printSummary(anyList(), any());
     }
 
     @Test
@@ -226,27 +226,38 @@ public class AllTest {
         List<ProcessingErrors> processingErrorsList = new ArrayList<>();
         AtomicInteger numberOfImagesFailedToProcess = new AtomicInteger(0);
 
-        all.processErrors(image, tag, e, processingErrorsList, numberOfImagesFailedToProcess);
+        all.processErrors(image, tag, e, processingErrorsList);
 
         assertEquals(processingErrorsList.size(), 1);
-        assertEquals(numberOfImagesFailedToProcess.get(), 1);
     }
 
     @Test
-    public void testPrintSummary() {
+    public void testPrintSummaryWhenImagesWereMissed() {
         ProcessingErrors processingErrors = mock(ProcessingErrors.class);
         All all = spy(new All());
         List<ProcessingErrors> processingErrorsList = Collections.singletonList(processingErrors);
         AtomicInteger numberOfImagesToProcess = new AtomicInteger(2);
-        AtomicInteger numberOfImagesFailedToProcess = new AtomicInteger(1);
         Exception failure = mock(Exception.class);
         when(processingErrors.getFailure()).thenReturn(Optional.of(failure));
 
-        all.printSummary(processingErrorsList, numberOfImagesToProcess, numberOfImagesFailedToProcess);
+        all.printSummary(processingErrorsList, numberOfImagesToProcess);
 
         verify(processingErrors, times(1)).getImageNameAndTag();
         verify(processingErrors, times(2)).getFailure();
-        assertEquals(numberOfImagesFailedToProcess.get(), 1);
+        assertEquals(numberOfImagesToProcess.get(), 2);
+    }
+
+    @Test
+    public void testPrintSummaryWhenAllImagesWereSuccessfullyProcessed() {
+        ProcessingErrors processingErrors = mock(ProcessingErrors.class);
+        All all = spy(new All());
+        List<ProcessingErrors> processingErrorsList = Collections.emptyList();
+        AtomicInteger numberOfImagesToProcess = new AtomicInteger(2);
+
+        all.printSummary(processingErrorsList, numberOfImagesToProcess);
+
+        verify(processingErrors, times(0)).getImageNameAndTag();
+        verify(processingErrors, times(0)).getFailure();
         assertEquals(numberOfImagesToProcess.get(), 2);
     }
 

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/AllTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/AllTest.java
@@ -15,7 +15,9 @@ import com.salesforce.dockerfileimageupdate.process.*;
 import com.salesforce.dockerfileimageupdate.storage.*;
 import com.salesforce.dockerfileimageupdate.utils.*;
 
+import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.kohsuke.github.*;
@@ -27,7 +29,7 @@ import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
 
 /**
- * Created by minho.park on 7/19/16.
+ * Created by avimanyum on 01/31/22.
  */
 public class AllTest {
     @Test
@@ -73,6 +75,8 @@ public class AllTest {
         verify(all, times(1)).getPullRequests();
         verify(pullRequests, times(1)).prepareToCreate(ns, pullRequestSender,
                 contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
+        verify(all, times(0)).processErrors(anyString(), anyString(), any(), anyList(), any());
+        verify(all, times(1)).printSummary(anyList(), any(), any());
     }
 
     @Test
@@ -117,10 +121,137 @@ public class AllTest {
         verify(all, times(1)).getPullRequests();
         verify(pullRequests, times(0)).prepareToCreate(ns, pullRequestSender,
                 contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
+        verify(all, times(0)).processErrors(anyString(), anyString(), any(), anyList(), any());
+        verify(all, times(1)).printSummary(anyList(), any(), any());
     }
 
     @Test
-    public void testGetCommon(){
+    public void testAllCommandSkipsSendingPRsIfSearchRaisesException() throws Exception {
+        Map<String, Object> nsMap = ImmutableMap.of(Constants.IMG,
+                "image", Constants.TAG,
+                "tag", Constants.STORE,
+                "store");
+        Namespace ns = new Namespace(nsMap);
+        All all = spy(new All());
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        GitHubJsonStore gitHubJsonStore = mock(GitHubJsonStore.class);
+        GitHubPullRequestSender pullRequestSender = mock(GitHubPullRequestSender.class);
+        GitForkBranch gitForkBranch = mock(GitForkBranch.class);
+        PullRequests pullRequests = mock(PullRequests.class);
+        Set<Map.Entry<String, JsonElement>> imageToTagStore = mock(Set.class);
+        when(dockerfileGitHubUtil.getGitHubJsonStore(anyString())).thenReturn(gitHubJsonStore);
+        when(gitHubJsonStore.parseStoreToImagesMap(dockerfileGitHubUtil, "store")).thenReturn(imageToTagStore);
+
+        Map.Entry<String, JsonElement> imageToTag = mock(Map.Entry.class);
+        Iterator<Map.Entry<String, JsonElement>> imageToTagStoreIterator = mock(Iterator.class);
+        when(imageToTagStoreIterator.next()).thenReturn(imageToTag);
+        when(imageToTagStoreIterator.hasNext()).thenReturn(true, false);
+        when(imageToTagStore.iterator()).thenReturn(imageToTagStoreIterator);
+        JsonElement jsonElement = mock(JsonElement.class);
+        when(imageToTag.getKey()).thenReturn("image1");
+        when(imageToTag.getValue()).thenReturn(jsonElement);
+        when(jsonElement.getAsString()).thenReturn("tag1");
+        when(all.getPullRequestSender(dockerfileGitHubUtil, ns)).thenReturn(pullRequestSender);
+        when(all.getGitForkBranch("image1", "tag1", ns)).thenReturn(gitForkBranch);
+        when(all.getPullRequests()).thenReturn(pullRequests);
+        PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
+        doNothing().when(pullRequests).prepareToCreate(ns, pullRequestSender,
+                contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
+        when(dockerfileGitHubUtil.findFilesWithImage(anyString(), anyMap(),  anyInt())).thenThrow(new GHException("some exception"));
+
+
+        all.execute(ns, dockerfileGitHubUtil);
+        verify(all, times(1)).getGitForkBranch(anyString(), anyString(), any());
+        verify(all, times(1)).getPullRequestSender(dockerfileGitHubUtil, ns);
+        verify(all, times(1)).getPullRequests();
+        verify(pullRequests, times(0)).prepareToCreate(ns, pullRequestSender,
+                contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
+        verify(all, times(1)).processErrors(anyString(), anyString(), any(), anyList(), any());
+        verify(all, times(1)).printSummary(anyList(), any(), any());
+    }
+
+    @Test
+    public void testAllCommandSkipsSendingPRsIfPRCreationRaisesException() throws Exception {
+        Map<String, Object> nsMap = ImmutableMap.of(Constants.IMG,
+                "image", Constants.TAG,
+                "tag", Constants.STORE,
+                "store");
+        Namespace ns = new Namespace(nsMap);
+        All all = spy(new All());
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        GitHubJsonStore gitHubJsonStore = mock(GitHubJsonStore.class);
+        GitHubPullRequestSender pullRequestSender = mock(GitHubPullRequestSender.class);
+        GitForkBranch gitForkBranch = mock(GitForkBranch.class);
+        PullRequests pullRequests = mock(PullRequests.class);
+        Set<Map.Entry<String, JsonElement>> imageToTagStore = mock(Set.class);
+        when(dockerfileGitHubUtil.getGitHubJsonStore(anyString())).thenReturn(gitHubJsonStore);
+        when(gitHubJsonStore.parseStoreToImagesMap(dockerfileGitHubUtil, "store")).thenReturn(imageToTagStore);
+
+        Map.Entry<String, JsonElement> imageToTag = mock(Map.Entry.class);
+        Iterator<Map.Entry<String, JsonElement>> imageToTagStoreIterator = mock(Iterator.class);
+        when(imageToTagStoreIterator.next()).thenReturn(imageToTag);
+        when(imageToTagStoreIterator.hasNext()).thenReturn(true, false);
+        when(imageToTagStore.iterator()).thenReturn(imageToTagStoreIterator);
+        JsonElement jsonElement = mock(JsonElement.class);
+        when(imageToTag.getKey()).thenReturn("image1");
+        when(imageToTag.getValue()).thenReturn(jsonElement);
+        when(jsonElement.getAsString()).thenReturn("tag1");
+        when(all.getPullRequestSender(dockerfileGitHubUtil, ns)).thenReturn(pullRequestSender);
+        when(all.getGitForkBranch("image1", "tag1", ns)).thenReturn(gitForkBranch);
+        when(all.getPullRequests()).thenReturn(pullRequests);
+        PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
+        List<PagedSearchIterable<GHContent>> contentsWithImageList = Collections.singletonList(contentsWithImage);
+        Optional<List<PagedSearchIterable<GHContent>>> optionalContentsWithImageList = Optional.of(contentsWithImageList);
+        doThrow(new IOException()).when(pullRequests).prepareToCreate(ns, pullRequestSender,
+                contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
+        when(dockerfileGitHubUtil.findFilesWithImage(anyString(), anyMap(),  anyInt())).thenReturn(optionalContentsWithImageList);
+
+
+        all.execute(ns, dockerfileGitHubUtil);
+        verify(all, times(1)).getGitForkBranch(anyString(), anyString(), any());
+        verify(all, times(1)).getPullRequestSender(dockerfileGitHubUtil, ns);
+        verify(all, times(1)).getPullRequests();
+        verify(pullRequests, times(1)).prepareToCreate(ns, pullRequestSender,
+                contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
+        verify(all, times(1)).processErrors(anyString(), anyString(), any(), anyList(), any());
+        verify(all, times(1)).printSummary(anyList(), any(), any());
+    }
+
+    @Test
+    public void testProcessErrors() {
+        All all = spy(new All());
+        String image = "image1";
+        String tag = "tag";
+        Exception e = new Exception();
+        List<ProcessingErrors> processingErrorsList = new ArrayList<>();
+        AtomicInteger numberOfImagesFailedToProcess = new AtomicInteger(0);
+
+        all.processErrors(image, tag, e, processingErrorsList, numberOfImagesFailedToProcess);
+
+        assertEquals(processingErrorsList.size(), 1);
+        assertEquals(numberOfImagesFailedToProcess.get(), 1);
+    }
+
+    @Test
+    public void testPrintSummary() {
+        ProcessingErrors processingErrors = mock(ProcessingErrors.class);
+        All all = spy(new All());
+        List<ProcessingErrors> processingErrorsList = Collections.singletonList(processingErrors);
+        AtomicInteger numberOfImagesToProcess = new AtomicInteger(2);
+        AtomicInteger numberOfImagesFailedToProcess = new AtomicInteger(1);
+        Exception failure = mock(Exception.class);
+        when(processingErrors.getFailure()).thenReturn(Optional.of(failure));
+
+        all.printSummary(processingErrorsList, numberOfImagesToProcess, numberOfImagesFailedToProcess);
+
+        verify(processingErrors, times(1)).getImageNameAndTag();
+        verify(processingErrors, times(2)).getFailure();
+        assertEquals(numberOfImagesFailedToProcess.get(), 1);
+        assertEquals(numberOfImagesToProcess.get(), 2);
+    }
+
+    @Test
+    public void testGetCommon() {
         All all = new All();
         PullRequests pullRequests = new PullRequests();
         assertEquals(pullRequests.getClass(), all.getPullRequests().getClass());

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/AllTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/AllTest.java
@@ -76,6 +76,50 @@ public class AllTest {
     }
 
     @Test
+    public void testAllCommandSkipsSendingPRsIfSearchReturnsEmpty() throws Exception {
+        Map<String, Object> nsMap = ImmutableMap.of(Constants.IMG,
+                "image", Constants.TAG,
+                "tag", Constants.STORE,
+                "store");
+        Namespace ns = new Namespace(nsMap);
+        All all = spy(new All());
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        GitHubJsonStore gitHubJsonStore = mock(GitHubJsonStore.class);
+        GitHubPullRequestSender pullRequestSender = mock(GitHubPullRequestSender.class);
+        GitForkBranch gitForkBranch = mock(GitForkBranch.class);
+        PullRequests pullRequests = mock(PullRequests.class);
+        Set<Map.Entry<String, JsonElement>> imageToTagStore = mock(Set.class);
+        when(dockerfileGitHubUtil.getGitHubJsonStore(anyString())).thenReturn(gitHubJsonStore);
+        when(gitHubJsonStore.parseStoreToImagesMap(dockerfileGitHubUtil, "store")).thenReturn(imageToTagStore);
+
+        Map.Entry<String, JsonElement> imageToTag = mock(Map.Entry.class);
+        Iterator<Map.Entry<String, JsonElement>> imageToTagStoreIterator = mock(Iterator.class);
+        when(imageToTagStoreIterator.next()).thenReturn(imageToTag);
+        when(imageToTagStoreIterator.hasNext()).thenReturn(true, false);
+        when(imageToTagStore.iterator()).thenReturn(imageToTagStoreIterator);
+        JsonElement jsonElement = mock(JsonElement.class);
+        when(imageToTag.getKey()).thenReturn("image1");
+        when(imageToTag.getValue()).thenReturn(jsonElement);
+        when(jsonElement.getAsString()).thenReturn("tag1");
+        when(all.getPullRequestSender(dockerfileGitHubUtil, ns)).thenReturn(pullRequestSender);
+        when(all.getGitForkBranch("image1", "tag1", ns)).thenReturn(gitForkBranch);
+        when(all.getPullRequests()).thenReturn(pullRequests);
+        PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
+        Optional<List<PagedSearchIterable<GHContent>>> optionalContentsWithImageList = Optional.empty();
+        doNothing().when(pullRequests).prepareToCreate(ns, pullRequestSender,
+                contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
+        when(dockerfileGitHubUtil.findFilesWithImage(anyString(), anyMap(),  anyInt())).thenReturn(optionalContentsWithImageList);
+
+
+        all.execute(ns, dockerfileGitHubUtil);
+        verify(all, times(1)).getGitForkBranch(anyString(), anyString(), any());
+        verify(all, times(1)).getPullRequestSender(dockerfileGitHubUtil, ns);
+        verify(all, times(1)).getPullRequests();
+        verify(pullRequests, times(0)).prepareToCreate(ns, pullRequestSender,
+                contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
+    }
+
+    @Test
     public void testGetCommon(){
         All all = new All();
         PullRequests pullRequests = new PullRequests();

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -236,26 +236,6 @@ public class DockerfileGitHubUtilTest {
         dockerfileGitHubUtil.findFilesWithImage(query, orgs, 1000);
     }
 
-    @DataProvider
-    public Object[][] inputLongImages() {
-        return new Object[][] {
-                {"dva-registry.internal.salesforce.com/sfci/dva-stratafile-smoketests/test-multi-docker-images-with-build-tags/frank-loves-docker", null},
-        };
-    }
-
-    @Test(dataProvider = "inputLongImages")
-    public void testFindFilesReturnsEmptyListIfQueryTooLong(String query, String org) throws Exception {
-        gitHubUtil = mock(GitHubUtil.class);
-
-        GHContentSearchBuilder ghContentSearchBuilder = mock(GHContentSearchBuilder.class);
-        when(gitHubUtil.startSearch()).thenReturn(ghContentSearchBuilder);
-        when(ghContentSearchBuilder.list()).thenThrow(new GHException("some exception"));
-
-        dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
-        Map<String, Boolean> orgs = Collections.unmodifiableMap(Collections.singletonMap(org, true));
-        assertEquals(dockerfileGitHubUtil.findFilesWithImage(query, orgs, 1000), Optional.empty());
-    }
-
     @Test
     public void testFindFiles() throws Exception {
         gitHubUtil = mock(GitHubUtil.class);

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -236,6 +236,26 @@ public class DockerfileGitHubUtilTest {
         dockerfileGitHubUtil.findFilesWithImage(query, orgs, 1000);
     }
 
+    @DataProvider
+    public Object[][] inputLongImages() {
+        return new Object[][] {
+                {"dva-registry.internal.salesforce.com/sfci/dva-stratafile-smoketests/test-multi-docker-images-with-build-tags/frank-loves-docker", null},
+        };
+    }
+
+    @Test(dataProvider = "inputLongImages")
+    public void testFindFilesReturnsEmptyListIfQueryTooLong(String query, String org) throws Exception {
+        gitHubUtil = mock(GitHubUtil.class);
+
+        GHContentSearchBuilder ghContentSearchBuilder = mock(GHContentSearchBuilder.class);
+        when(gitHubUtil.startSearch()).thenReturn(ghContentSearchBuilder);
+        when(ghContentSearchBuilder.list()).thenThrow(new GHException("some exception"));
+
+        dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
+        Map<String, Boolean> orgs = Collections.unmodifiableMap(Collections.singletonMap(org, true));
+        assertEquals(dockerfileGitHubUtil.findFilesWithImage(query, orgs, 1000), Optional.empty());
+    }
+
     @Test
     public void testFindFiles() throws Exception {
         gitHubUtil = mock(GitHubUtil.class);


### PR DESCRIPTION
For the `all` subcommand, if there is an exception thrown while searching for one image, that exception should be handled so that the `all` subcommand can continue on to the next image on the image tag store.