### PR TITLE
Catching IOException when the image name is invalid

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -74,7 +74,7 @@ public class All implements ExecutableWithNamespace {
                         }
                     });
                 }
-            } catch (GHException | HttpException e){
+            } catch (GHException | IOException e){
                 log.error("Could not perform Github search for the image {}. Trying to proceed...", image);
                 processErrors(image, tag, e, imagesThatCouldNotBeProcessed);
             }


### PR DESCRIPTION
On running the All subcommand, if there is an image in the tag store that has an invalid image name, the findFilesWithImage method throws an IOException [here](https://github.com/salesforce/dockerfile-image-update/blob/master/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java#L86). However, in the All subcommand execute path we are not catching this [exception](https://github.com/salesforce/dockerfile-image-update/blob/master/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java#L77). As a result, if the image tag store has one entry with an invalid image name, the all subcommand will exit once it hits that entry and not process the following entries. 
This fix allows us to catch these exceptions and move on to processing the following images in the image tag store. 