### PR TITLE
Handling error messaging when PR creation fails with Invalid code error

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java
@@ -108,12 +108,17 @@ public class GitHubUtil {
             log.warn("Handling error with pull request creation... {}", e.getMessage());
             JsonElement root = JsonParser.parseString(e.getMessage());
             JsonArray errorJson = root.getAsJsonObject().get("errors").getAsJsonArray();
-            String error = errorJson.get(0).getAsJsonObject().get("message").getAsString();
+            String error = "";
+            if (errorJson.get(0).getAsJsonObject().has("message")) {
+                error = errorJson.get(0).getAsJsonObject().get("message").getAsString();
+            } else {
+                error = "PR head has invalid code.";
+            }
             log.info("error: {}", error);
             if (error.startsWith("A pull request already exists")) {
                 log.info("NOTE: {} New commits may have been added to the pull request.", error);
                 return 0;
-            } else if (error.startsWith("No commits between")) {
+            } else if (error.startsWith("No commits between") || error.startsWith("PR head has invalid code.")) {
                 log.warn("NOTE: {} Pull request was not created.", error);
                 return 1;
             } else {

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtilTest.java
@@ -120,6 +120,19 @@ public class GitHubUtilTest {
         assertEquals(gitHubUtil.createPullReq(origRepo, "branch", forkRepo, "title", "body"), 1);
         verify(origRepo, times(1)).createPullRequest(eq("title"), eq("owner:branch"), eq("master"), eq("body"));
     }
+    @Test
+    public void testCreatePullReq_errorCase1_withInvalidCode() throws Exception {
+        GitHub github = mock(GitHub.class);
+        GitHubUtil gitHubUtil = new GitHubUtil(github);
+        GHRepository origRepo = mock(GHRepository.class);
+        when(origRepo.getDefaultBranch()).thenReturn("master");
+        when(origRepo.createPullRequest(eq("title"), eq("owner:branch"), eq("master"), eq("body")))
+                .thenThrow(new IOException("{\"message\":\"Validation Failed\",\"errors\":[{\"resource\":\"PullRequest\",\"field\":\"head\",\"code\":\"invalid\"}],\"documentation_url\":\"https://developer.github.com/enterprise/2.6/v3/pulls/#create-a-pull-request\"}"));
+        GHRepository forkRepo = mock(GHRepository.class);
+        when(forkRepo.getOwnerName()).thenReturn("owner");
+        assertEquals(gitHubUtil.createPullReq(origRepo, "branch", forkRepo, "title", "body"), 1);
+        verify(origRepo, times(1)).createPullRequest(eq("title"), eq("owner:branch"), eq("master"), eq("body"));
+    }
 
     @Test
     public void testTryRetrievingRepository() throws Exception {


### PR DESCRIPTION
There are cases when the PR creation fails and the exception message thrown looks like this:
`{"message":"Validation Failed","errors":[{"resource":"PullRequest","field":"head","code":"invalid"}],"documentation_url":"https://docs.github.com/enterprise/3.1/rest/reference/pulls#create-a-pull-request"}`

In such case, [this](https://github.com/salesforce/dockerfile-image-update/blob/master/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java#L111) line will throw a NullPointerException since the JsonArray does not have a field called `message`. Unfortunately, since this error is thrown inside the `catch` block, it is not handled and essentially terminates the process. 

This PR checks for the existence of this key inside the Json object before trying to get it. If it does not find it there, it assumes that the error was due to the head having invalid code (error message shown above). In such a scenario, the [method](https://github.com/salesforce/dockerfile-image-update/blob/master/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtil.java#L96) returns an error code of 1, so that we can proceed to safely deleting the forked repo [here](https://github.com/salesforce/dockerfile-image-update/blob/master/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java#L340) 