### PR TITLE
Resetting the list of orgs to include or exclude in the search for each image

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -40,13 +40,6 @@ public class All implements ExecutableWithNamespace {
         Set<Map.Entry<String, JsonElement>> imageToTagStore =
                 this.dockerfileGitHubUtil.getGitHubJsonStore(ns.get(Constants.STORE)).parseStoreToImagesMap(dockerfileGitHubUtil, ns.get(Constants.STORE));
         Integer gitApiSearchLimit = ns.get(Constants.GIT_API_SEARCH_LIMIT);
-        Map<String, Boolean> orgsToIncludeInSearch = new HashMap<>();
-        if (ns.get(Constants.GIT_ORG) != null) {
-            // If there is a Git org specified, that needs to be included in the search query. In
-            // the orgsToIncludeInSearch a true value associated with an org name ensures that
-            // the org gets included in the search query.
-            orgsToIncludeInSearch.put(ns.get(Constants.GIT_ORG), true);
-        }
         List<ProcessingErrors> imagesThatCouldNotBeProcessed = new LinkedList<>();
         AtomicInteger numberOfImagesToProcess = new AtomicInteger();
         for (Map.Entry<String, JsonElement> imageToTag : imageToTagStore) {
@@ -59,7 +52,13 @@ public class All implements ExecutableWithNamespace {
                 GitForkBranch gitForkBranch = getGitForkBranch(image, tag, ns);
 
                 log.info("Finding Dockerfiles with the image name {}...", image);
-
+                Map<String, Boolean> orgsToIncludeInSearch = new HashMap<>();
+                if (ns.get(Constants.GIT_ORG) != null) {
+                    // If there is a Git org specified, that needs to be included in the search query. In
+                    // the orgsToIncludeInSearch a true value associated with an org name ensures that
+                    // the org gets included in the search query.
+                    orgsToIncludeInSearch.put(ns.get(Constants.GIT_ORG), true);
+                }
                 Optional<List<PagedSearchIterable<GHContent>>> contentsWithImage =
                         this.dockerfileGitHubUtil.findFilesWithImage(image, orgsToIncludeInSearch, gitApiSearchLimit);
 

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -40,8 +40,6 @@ public class All implements ExecutableWithNamespace {
         Set<Map.Entry<String, JsonElement>> imageToTagStore =
                 this.dockerfileGitHubUtil.getGitHubJsonStore(ns.get(Constants.STORE)).parseStoreToImagesMap(dockerfileGitHubUtil, ns.get(Constants.STORE));
         Integer gitApiSearchLimit = ns.get(Constants.GIT_API_SEARCH_LIMIT);
-        List<ProcessingErrors> imagesThatCouldNotBeProcessed = new LinkedList<>();
-        AtomicInteger numberOfImagesToProcess = new AtomicInteger();
         Map<String, Boolean> orgsToIncludeInSearch = new HashMap<>();
         if (ns.get(Constants.GIT_ORG) != null) {
             // If there is a Git org specified, that needs to be included in the search query. In
@@ -49,6 +47,8 @@ public class All implements ExecutableWithNamespace {
             // the org gets included in the search query.
             orgsToIncludeInSearch.put(ns.get(Constants.GIT_ORG), true);
         }
+        List<ProcessingErrors> imagesThatCouldNotBeProcessed = new LinkedList<>();
+        AtomicInteger numberOfImagesToProcess = new AtomicInteger();
         for (Map.Entry<String, JsonElement> imageToTag : imageToTagStore) {
             numberOfImagesToProcess.getAndIncrement();
             String image = imageToTag.getKey();
@@ -59,6 +59,7 @@ public class All implements ExecutableWithNamespace {
                 GitForkBranch gitForkBranch = getGitForkBranch(image, tag, ns);
 
                 log.info("Finding Dockerfiles with the image name {}...", image);
+
                 Optional<List<PagedSearchIterable<GHContent>>> contentsWithImage =
                         this.dockerfileGitHubUtil.findFilesWithImage(image, orgsToIncludeInSearch, gitApiSearchLimit);
 

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -42,6 +42,13 @@ public class All implements ExecutableWithNamespace {
         Integer gitApiSearchLimit = ns.get(Constants.GIT_API_SEARCH_LIMIT);
         List<ProcessingErrors> imagesThatCouldNotBeProcessed = new LinkedList<>();
         AtomicInteger numberOfImagesToProcess = new AtomicInteger();
+        Map<String, Boolean> orgsToIncludeInSearch = new HashMap<>();
+        if (ns.get(Constants.GIT_ORG) != null) {
+            // If there is a Git org specified, that needs to be included in the search query. In
+            // the orgsToIncludeInSearch a true value associated with an org name ensures that
+            // the org gets included in the search query.
+            orgsToIncludeInSearch.put(ns.get(Constants.GIT_ORG), true);
+        }
         for (Map.Entry<String, JsonElement> imageToTag : imageToTagStore) {
             numberOfImagesToProcess.getAndIncrement();
             String image = imageToTag.getKey();
@@ -52,13 +59,6 @@ public class All implements ExecutableWithNamespace {
                 GitForkBranch gitForkBranch = getGitForkBranch(image, tag, ns);
 
                 log.info("Finding Dockerfiles with the image name {}...", image);
-                Map<String, Boolean> orgsToIncludeInSearch = new HashMap<>();
-                if (ns.get(Constants.GIT_ORG) != null) {
-                    // If there is a Git org specified, that needs to be included in the search query. In
-                    // the orgsToIncludeInSearch a true value associated with an org name ensures that
-                    // the org gets included in the search query.
-                    orgsToIncludeInSearch.put(ns.get(Constants.GIT_ORG), true);
-                }
                 Optional<List<PagedSearchIterable<GHContent>>> contentsWithImage =
                         this.dockerfileGitHubUtil.findFilesWithImage(image, orgsToIncludeInSearch, gitApiSearchLimit);
 

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -177,7 +177,7 @@ public class DockerfileGitHubUtil {
         Optional<List<PagedSearchIterable<GHContent>>> contentsForOrgWithMaximumHits;
         contentsForOrgWithMaximumHits = findFilesWithImage(image, orgsToInclude, gitApiSearchLimit);
 
-        final Map<String, Boolean> orgsToExcludeFromSearch = new HashMap(orgsToExclude);
+        final Map<String, Boolean> orgsToExcludeFromSearch = new HashMap<>(orgsToExclude);
         orgsToExcludeFromSearch.put(orgWithMaximumHits, false);
         log.info("Running search by excluding the orgs {}.", orgsToExcludeFromSearch.keySet());
         Optional<List<PagedSearchIterable<GHContent>>> contentsExcludingOrgWithMaximumHits;

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -177,10 +177,9 @@ public class DockerfileGitHubUtil {
         Optional<List<PagedSearchIterable<GHContent>>> contentsForOrgWithMaximumHits;
         contentsForOrgWithMaximumHits = findFilesWithImage(image, orgsToInclude, gitApiSearchLimit);
 
-        Map<String, Boolean> orgsToExcludeFromSearch = new HashMap<>();
-        orgsToExcludeFromSearch.putAll(orgsToExclude);
+        final Map<String, Boolean> orgsToExcludeFromSearch = new HashMap(orgsToExclude);
         orgsToExcludeFromSearch.put(orgWithMaximumHits, false);
-        log.info("Running search by excluding the orgs {}.", orgsToExcludeFromSearch.keySet().toString());
+        log.info("Running search by excluding the orgs {}.", orgsToExcludeFromSearch.keySet());
         Optional<List<PagedSearchIterable<GHContent>>> contentsExcludingOrgWithMaximumHits;
         contentsExcludingOrgWithMaximumHits = findFilesWithImage(image, orgsToExcludeFromSearch, gitApiSearchLimit);
         if (contentsForOrgWithMaximumHits.isPresent()) {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -177,10 +177,12 @@ public class DockerfileGitHubUtil {
         Optional<List<PagedSearchIterable<GHContent>>> contentsForOrgWithMaximumHits;
         contentsForOrgWithMaximumHits = findFilesWithImage(image, orgsToInclude, gitApiSearchLimit);
 
-        orgsToExclude.put(orgWithMaximumHits, false);
-        log.info("Running search by excluding the orgs {}.", orgsToExclude.keySet().toString());
+        Map<String, Boolean> orgsToExcludeFromSearch = new HashMap<>();
+        orgsToExcludeFromSearch.putAll(orgsToExclude);
+        orgsToExcludeFromSearch.put(orgWithMaximumHits, false);
+        log.info("Running search by excluding the orgs {}.", orgsToExcludeFromSearch.keySet().toString());
         Optional<List<PagedSearchIterable<GHContent>>> contentsExcludingOrgWithMaximumHits;
-        contentsExcludingOrgWithMaximumHits = findFilesWithImage(image, orgsToExclude, gitApiSearchLimit);
+        contentsExcludingOrgWithMaximumHits = findFilesWithImage(image, orgsToExcludeFromSearch, gitApiSearchLimit);
         if (contentsForOrgWithMaximumHits.isPresent()) {
             allContentsWithImage.addAll(contentsForOrgWithMaximumHits.get());
         }

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -330,6 +330,7 @@ public class DockerfileGitHubUtilTest {
         Map<String, Boolean> orgsToIncludeOrExclude = new HashMap<>();
 
         assertEquals((dockerfileGitHubUtil.getSearchResultsExcludingOrgWithMostHits("image", contentsWithImage, orgsToIncludeOrExclude, 1000)).get().size(), 2);
+        assertEquals(orgsToIncludeOrExclude.size(), 0);
     }
 
     @Test

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -330,6 +330,7 @@ public class DockerfileGitHubUtilTest {
         Map<String, Boolean> orgsToIncludeOrExclude = new HashMap<>();
 
         assertEquals((dockerfileGitHubUtil.getSearchResultsExcludingOrgWithMostHits("image", contentsWithImage, orgsToIncludeOrExclude, 1000)).get().size(), 2);
+        //This check ensures that the parameter passed to the method is not modified. Instead, the method creates a local copy of the map and modifies that.
         assertEquals(orgsToIncludeOrExclude.size(), 0);
     }
 


### PR DESCRIPTION
While running the `all` subcommand, there is a Git search that happens for each image found in the tag store one after the other. While processing one of the images, if the hashmap orgsToIncludeInSearch is modified (this can happen one image returns more than 1000 search results. Refer to [this](https://github.com/salesforce/dockerfile-image-update/pull/276) for more details), the modified map persists and is carried over while performing the search for the next image in the tag store. This is a bug. 
This PR resets the hashmap before performing the search for each image.