### PR TITLE
Label triggers are creating duplicate releases

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,8 +1,6 @@
 name: Release Drafter
 
 on:
-  label:
-    types: [created, deleted]
   workflow_dispatch:
   push:
     branches:


### PR DESCRIPTION
It seems like these triggers are kinda counterproductive. It'd be good
to keep the workflow_dispatch but it's unclear whether that will also
create a duplicate so I'll keep it for now.