### PR TITLE
Use stream to look for error message prefixes

### DIFF
--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtilTest.java
@@ -131,7 +131,7 @@ public class GitHubUtilTest {
         GHRepository forkRepo = mock(GHRepository.class);
         when(forkRepo.getOwnerName()).thenReturn("owner");
         assertEquals(gitHubUtil.createPullReq(origRepo, "branch", forkRepo, "title", "body"), 1);
-        verify(origRepo, times(1)).createPullRequest(eq("title"), eq("owner:branch"), eq("master"), eq("body"));
+        verify(origRepo).createPullRequest(eq("title"), eq("owner:branch"), eq("master"), eq("body"));
     }
 
     @Test


### PR DESCRIPTION
This PR creates an Array of potential error messages and streams through them to check for the existence of one. This way we will not have to modify the conditional check even if there are more error prefixes we add in the future.