### PR TITLE
Fixed ignore PR comment docker build issue

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
@@ -83,7 +83,7 @@ public class CommandLine {
                 .setDefault(false)
                 .help("Only update image tag store. Skip creating PRs");
         parser.addArgument("-x")
-                .help("comment snippet mentioned in next line after FROM instruction for ignoring a child image. " +
+                .help("comment snippet mentioned in line just before FROM instruction for ignoring a child image. " +
                         "Defaults to 'no-dfiu'");
         return parser;
     }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
@@ -83,7 +83,7 @@ public class CommandLine {
                 .setDefault(false)
                 .help("Only update image tag store. Skip creating PRs");
         parser.addArgument("-x")
-                .help("comment snippet after FROM instruction for ignoring a child image. " +
+                .help("comment snippet mentioned in next line after FROM instruction for ignoring a child image. " +
                         "Defaults to 'no-dfiu'");
         return parser;
     }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/FromInstruction.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/FromInstruction.java
@@ -14,7 +14,6 @@ public class FromInstruction {
 
     private static final String NAME = "FROM";
     private static final String INVALID_INSTRUCTION_LINE = "You have not provided a valid FROM instruction line.";
-    private static final String NO_DFIU = "no-dfiu";
     /**
      * The name of the base image
      */
@@ -189,24 +188,6 @@ public class FromInstruction {
             return true;
         }
         return !tag.trim().equals(expectedTag.trim());
-    }
-
-    /**
-     * Determines whether the comment has mentioned {@code ignoreImageString} to ignore creating dfiu PR
-     * If {@code ignoreImageString} present in comment, PR should be ignored
-     * If {@code ignoreImageString} is empty, then by default 'no-dfiu' comment will be searched
-     * @param ignoreImageString comment to search
-     * @return {@code true} if comment is found
-     */
-    public boolean ignorePR(String ignoreImageString) {
-        if (hasComments()) {
-            if (StringUtils.isNotBlank(ignoreImageString)) {
-                return comments.contains(ignoreImageString);
-            } else {
-                return comments.contains(NO_DFIU);
-            }
-        }
-        return false;
     }
 
     public String getTag() {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -344,7 +344,7 @@ public class DockerfileGitHubUtil {
      */
     protected boolean ignorePRCommentPresent(String line, String ignoreImageString) {
         final String tester = Optional.ofNullable(ignoreImageString).filter(StringUtils::isNotBlank).orElse(NO_DFIU);
-        return StringUtils.isNotBlank(line) && line.trim().startsWith("#") && line.contains(tester);
+        return StringUtils.isNotBlank(line) && line.trim().startsWith("#") && line.substring(line.indexOf("#") + 1).trim().equals(tester);
     }
 
     public GitHubJsonStore getGitHubJsonStore(String store) {

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/FromInstructionTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/FromInstructionTest.java
@@ -239,26 +239,4 @@ public class FromInstructionTest {
     public void isFromInstructionWithThisImageAndOlderTag(String line, String imageName, String imageTag, boolean expectedResult) {
         assertEquals(FromInstruction.isFromInstructionWithThisImageAndOlderTag(line, imageName, imageTag), expectedResult);
     }
-
-    @DataProvider
-    public Object[][] commentDataNoDfiu() {
-        return new Object[][] {
-                {"FROM image:tag as builder",       false},
-                {"FROM image:tag#no-dfiu",          true},
-                {"FROM image:tag # no-dfiu",        true},
-                {"FROM image:tag\t# no-dfiu",       true},
-                {"FROM image:\t# no-dfiu # # # ",   true},
-                {"FROM image:",                     false},
-                {"FROM image:test # :no-dfiu",      true},
-                {"FROM image:test # no-dfiu added comments for ignoring dfiu PR",      true},
-                {"FROM no-dfiu:test",               false},
-                {"FROM image:no-dfiu",              false},
-                {"FROM no-dfiu",                    false}
-        };
-    }
-
-    @Test(dataProvider = "commentDataNoDfiu")
-    public void testCommentsWithNoDfiuParsedCorrectly(String input, Boolean expectedResult) {
-        assertEquals(new FromInstruction(input).ignorePR(""), expectedResult);
-    }
 }

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -817,7 +817,7 @@ public class DockerfileGitHubUtilTest {
                 { "# ignore-pr\nFROM image:original", "", "# ignore-pr\nFROM image:changed\n"},
                 { "# no-dfiu\nFROM image:original\nFROM image:abcd", "", "# no-dfiu\nFROM image:original\nFROM image:changed\n"},
                 { "# no-dfiu\nFROM image:original\n# no-dfiu\nFROM image:abcd", "", "# no-dfiu\nFROM image:original\n# no-dfiu\nFROM image:abcd\n"},
-                { "# I don't want PR for this hence mentioning no-dfiu\nFROM image:original", "", "# I don't want PR for this hence mentioning no-dfiu\nFROM image:original\n"},
+                { "#no-dfiu\nFROM image:original", "", "#no-dfiu\nFROM image:original\n"},
         };
     }
 
@@ -841,10 +841,10 @@ public class DockerfileGitHubUtilTest {
                 {"#no-dfiu",            "",         true},
                 {"# no-dfiu",           "",         true},
                 {"\t# no-dfiu",         "",         true},
-                {"\t# no-dfiu # # # ",  "",         true},
+                {"\t# no-dfiu # # # ",  "",         false},
                 {"#\n",                 "",         false},
-                {"# :no-dfiu",          "",         true},
-                {"# no-dfiu added comments for ignoring dfiu PR", "",       true},
+                {"# :no-dfiu",          "",         false},
+                {"# no-dfiu added comments for ignoring dfiu PR", "",       false},
                 {"#FROM a:b",           "",                                 false},
                 {"#ignore-pr",          "ignore-pr",                        true},
                 {"#ignore-pr",          "ignore pr",                        false}

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -538,40 +538,38 @@ public class DockerfileGitHubUtilTest {
     @DataProvider
     public Object[][] inputlines() throws Exception {
         return new Object[][]{
-                {"image1", "3", "FROM image1_blahblah", "", false},
-                {"image1", "3", "  FROM image1_blahblah", "", false},
-                {"image1", "3", "FROM image1_blahblah  ", "", false},
-                {"image1", "3", "FROM image1_blahblah\t", "", false},
-                {"image1", "3", "FROM image1_blahblah:2", "", false},
-                {"image2", "4", "FROM image2_blahblah:latest", "", false},
-                {"image4", "9", "FROM image4:9", "", false},
-                {"image5", "246", "FROM image5_", "", false},
-                {"image6", "26", "FROM image7", "", false},
-                {"image8", "245", "FROM image8:245", "", false},
-                {"image8", "245", "FROM image8: 245", "", true},
-                {"image3", "7", "FROM image3", "", true},
-                {"image3", "7", "  FROM image3", "", true},
-                {"image3", "7", "FROM image3  ", "",  true},
-                {"image3", "7", "\tFROM image3\t", "", true},
-                {"image7", "98", "FROM image7:4", "", true},
-                {"image7", "98", "FROM image7: 4", "", true},
+                {"image1", "3", "FROM image1_blahblah", false},
+                {"image1", "3", "  FROM image1_blahblah", false},
+                {"image1", "3", "FROM image1_blahblah  ", false},
+                {"image1", "3", "FROM image1_blahblah\t", false},
+                {"image1", "3", "FROM image1_blahblah:2", false},
+                {"image2", "4", "FROM image2_blahblah:latest", false},
+                {"image4", "9", "FROM image4:9", false},
+                {"image5", "246", "FROM image5_", false},
+                {"image6", "26", "FROM image7", false},
+                {"image8", "245", "FROM image8:245", false},
+                {"image8", "245", "FROM image8: 245", true},
+                {"image3", "7", "FROM image3", true},
+                {"image3", "7", "  FROM image3", true},
+                {"image3", "7", "FROM image3  ",  true},
+                {"image3", "7", "\tFROM image3\t", true},
+                {"image7", "98", "FROM image7:4", true},
+                {"image7", "98", "FROM image7: 4", true},
                 {"image124516418023_1085-1-1248571", "7357",
-                        "FROM image124516418023_1085-1-1248571:18026809126359806124890356219518632048125", "", true},
+                        "FROM image124516418023_1085-1-1248571:18026809126359806124890356219518632048125", true},
                 {"image", "1234",
-                        "FROM image:1234", "# no-dfiu", false},
+                        "FROM image:1234", false},
                 {"image", "1234",
-                        "FROM image:1234", "# I don't want PR for this hence no-dfiu", false},
+                        "FROM image:1234", false},
         };
     }
 
     @Test(dataProvider = "inputlines")
     public void testChangeIfDockerfileBaseImageLine(String img, String tag,
-                                                    String line, String nextLine, boolean expected) throws Exception {
+                                                    String line, boolean expected) throws Exception {
         gitHubUtil = mock(GitHubUtil.class);
         dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
-        InputStream stream = new ByteArrayInputStream(nextLine.getBytes(Charset.forName("UTF-8")));
-        BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
-        assertEquals(dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(reader, img, tag, new StringBuilder(), line, ""),
+        assertEquals(dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(img, tag, new StringBuilder(), line),
                 expected);
     }
 
@@ -582,13 +580,11 @@ public class DockerfileGitHubUtilTest {
         StringBuilder stringBuilder = new StringBuilder();
         String img = "image";
         String tag = "7357";
-        InputStream stream = new ByteArrayInputStream("".getBytes(Charset.forName("UTF-8")));
-        BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
-        dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(reader, img, tag, stringBuilder, "hello", "");
-        dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(reader, img, tag, stringBuilder, "FROM image:blah", "");
-        dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(reader, img, tag, stringBuilder, "world", "");
-        dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(reader, img, tag, stringBuilder, "this is a test", "");
-        assertEquals(stringBuilder.toString(), "hello\nFROM image:7357\nworld\nthis is a test\n", "");
+        dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(img, tag, stringBuilder, "hello");
+        dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(img, tag, stringBuilder, "FROM image:blah");
+        dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(img, tag, stringBuilder, "world");
+        dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(img, tag, stringBuilder, "this is a test");
+        assertEquals(stringBuilder.toString(), "hello\nFROM image:7357\nworld\nthis is a test\n");
     }
 
     @Test
@@ -598,13 +594,11 @@ public class DockerfileGitHubUtilTest {
         StringBuilder stringBuilder = new StringBuilder();
         String img = "image";
         String tag = "7357";
-        InputStream stream = new ByteArrayInputStream("".getBytes(Charset.forName("UTF-8")));
-        BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
-        dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(reader, img, tag, stringBuilder, "hello", "");
-        dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(reader, img, tag, stringBuilder, "FROM image", "");
-        dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(reader, img, tag, stringBuilder, "world", "");
-        dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(reader, img, tag, stringBuilder, "this is a test", "");
-        assertEquals(stringBuilder.toString(), "hello\nFROM image:7357\nworld\nthis is a test\n", "");
+        dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(img, tag, stringBuilder, "hello");
+        dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(img, tag, stringBuilder, "FROM image");
+        dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(img, tag, stringBuilder, "world");
+        dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(img, tag, stringBuilder, "this is a test");
+        assertEquals(stringBuilder.toString(), "hello\nFROM image:7357\nworld\nthis is a test\n");
     }
 
     @Test
@@ -816,48 +810,51 @@ public class DockerfileGitHubUtilTest {
     @DataProvider
     public Object[][] fromInstructionWithIgnoreStringData() {
         return new Object[][] {
-                { "FROM image:original", "# no-dfiu", "", "FROM image:original\n# no-dfiu\n"},
-                { "FROM image:original", "# no-dfiu", "dont-ignore", "FROM image:changed\n# no-dfiu\n"},
-                { "FROM image:original", "# ignore-pr", "dont-ignore", "FROM image:changed\n# ignore-pr\n"},
-                { "FROM image:original", "# ignore-pr", "ignore-pr", "FROM image:original\n# ignore-pr\n"},
-                { "FROM image:original", "# ignore-pr", "", "FROM image:changed\n# ignore-pr\n"}
+                { "# no-dfiu\nFROM image:original", "", "# no-dfiu\nFROM image:original\n"},
+                { "# no-dfiu\nFROM image:original", "dont-ignore", "# no-dfiu\nFROM image:changed\n"},
+                { "# ignore-pr\nFROM image:original", "dont-ignore", "# ignore-pr\nFROM image:changed\n"},
+                { "# ignore-pr\nFROM image:original", "ignore-pr", "# ignore-pr\nFROM image:original\n"},
+                { "# ignore-pr\nFROM image:original", "", "# ignore-pr\nFROM image:changed\n"},
+                { "# no-dfiu\nFROM image:original\nFROM image:abcd", "", "# no-dfiu\nFROM image:original\nFROM image:changed\n"},
+                { "# no-dfiu\nFROM image:original\n# no-dfiu\nFROM image:abcd", "", "# no-dfiu\nFROM image:original\n# no-dfiu\nFROM image:abcd\n"},
+                { "# I don't want PR for this hence mentioning no-dfiu\nFROM image:original", "", "# I don't want PR for this hence mentioning no-dfiu\nFROM image:original\n"},
         };
     }
 
     @Test(dataProvider = "fromInstructionWithIgnoreStringData")
-    public void testDockerfileWithIgnoreImageString(String fromLine, String nextLine, String ignoreImageString, String outputLines) throws IOException {
+    public void testDockerfileWithIgnoreImageString(String dockerfileLines, String ignoreImageString, String outputLines) throws IOException {
         gitHubUtil = mock(GitHubUtil.class);
         dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
         StringBuilder stringBuilder = new StringBuilder();
         String img = "image";
         String tag = "changed";
-        InputStream stream = new ByteArrayInputStream(nextLine.getBytes(Charset.forName("UTF-8")));
+        InputStream stream = new ByteArrayInputStream(dockerfileLines.getBytes(Charset.forName("UTF-8")));
         BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
-        dockerfileGitHubUtil.changeIfDockerfileBaseImageLine(reader, img, tag, stringBuilder, fromLine, ignoreImageString);
+        dockerfileGitHubUtil.rewriteDockerfile(img, tag, reader, stringBuilder, ignoreImageString);
         assertEquals(stringBuilder.toString(), outputLines, "");
     }
 
     @DataProvider
     public Object[][] commentDataNoDfiu() {
         return new Object[][] {
-                {"COPY a b",        "",       false},
-                {"#no-dfiu",        "",       true},
-                {"# no-dfiu",       "",       true},
-                {"\t# no-dfiu",     "",       true},
-                {"\t# no-dfiu # # # ", "",    true},
-                {"\n",              "",       false},
-                {"# :no-dfiu",      "",       true},
+                {"#FROM alpine:latest", "",         false},
+                {"#no-dfiu",            "",         true},
+                {"# no-dfiu",           "",         true},
+                {"\t# no-dfiu",         "",         true},
+                {"\t# no-dfiu # # # ",  "",         true},
+                {"#\n",                 "",         false},
+                {"# :no-dfiu",          "",         true},
                 {"# no-dfiu added comments for ignoring dfiu PR", "",       true},
-                {" ",               "COPY a b ",                            false},
-                {"#ignore-pr",      "ignore-pr",                            true},
-                {"#ignore-pr",      "ignore pr",                            false}
+                {"#FROM a:b",           "",                                 false},
+                {"#ignore-pr",          "ignore-pr",                        true},
+                {"#ignore-pr",          "ignore pr",                        false}
         };
     }
 
     @Test(dataProvider = "commentDataNoDfiu")
-    public void testCommentsWithNoDfiuParsedCorrectly(String nextLine, String ignoreImageString, Boolean expectedResult) throws IOException {
+    public void testCommentsWithNoDfiuParsedCorrectly(String line, String ignoreImageString, Boolean expectedResult) throws IOException {
         gitHubUtil = mock(GitHubUtil.class);
         dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
-        assertEquals(dockerfileGitHubUtil.ignorePR(nextLine,ignoreImageString), expectedResult);
+        assertEquals(dockerfileGitHubUtil.ignorePRCommentPresent(line, ignoreImageString), expectedResult);
     }
 }


### PR DESCRIPTION
Fixed ignore PR comment docker build issue by changing functionality to read next line after FROM instruction. If next line is a comment after FROM instruction matching ignorePRString or no-dfiu, PR will not be created