### PR TITLE
PR to fix https://github.com/salesforce/dockerfile-image-update/issues/236, to bring in support for sending PRs to docker-compose files

### DIFF
--- a/dockerfile-image-update/pom.xml
+++ b/dockerfile-image-update/pom.xml
@@ -97,8 +97,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
@@ -48,7 +48,7 @@ public class CommandLine {
         DockerfileGitHubUtil dockerfileGitHubUtil = initializeDockerfileGithubUtil(ns.get(Constants.GIT_API));
 
         /* Execute given command. */
-        ((ExecutableWithNamespace)runClass.newInstance()).execute(ns, dockerfileGitHubUtil);
+        ((ExecutableWithNamespace)runClass.getDeclaredConstructor().newInstance()).execute(ns, dockerfileGitHubUtil);
     }
 
     static ArgumentParser getArgumentParser() {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
@@ -84,6 +84,11 @@ public class CommandLine {
         parser.addArgument("-x")
                 .help("comment snippet mentioned in line just before FROM instruction for ignoring a child image. " +
                         "Defaults to 'no-dfiu'");
+        parser.addArgument("-t", "--" + Constants.FILENAMES_TO_SEARCH)
+                .type(String.class)
+                .setDefault("Dockerfile,docker-compose")
+                .help("Comma seperated list of filenames to search & update for PR creation" +
+                        "(default: Dockerfile,docker-compose)");
         return parser;
     }
 

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
@@ -83,18 +83,19 @@ public class CommandLine {
                 .setDefault(false)
                 .help("Only update image tag store. Skip creating PRs");
         parser.addArgument("-x")
-                .help("comment snippet mentioned in line just before FROM instruction for ignoring a child image. " +
+                .help("comment snippet mentioned in line just before 'FROM' instruction(Dockerfile)" +
+                        "or 'image' instruction(docker-compose) for ignoring a child image. " +
                         "Defaults to 'no-dfiu'");
+        parser.addArgument("-t", "--" + FILE_NAMES_TO_SEARCH)
+                .type(String.class)
+                .setDefault("Dockerfile,docker-compose")
+                .help("Comma seperated list of filenames to search & update for PR creation" +
+                        "(default: Dockerfile,docker-compose)");
         parser.addArgument("-r", "--" + RATE_LIMIT_PR_CREATION)
                 .type(String.class)
                 .setDefault("")
                 .required(false)
                 .help("Use RateLimiting when sending PRs. RateLimiting is enabled only if this value is set it's disabled by default.");
-        parser.addArgument("-t", "--" + Constants.FILENAMES_TO_SEARCH)
-                .type(String.class)
-                .setDefault("Dockerfile,docker-compose")
-                .help("Comma seperated list of filenames to search & update for PR creation" +
-                        "(default: Dockerfile,docker-compose)");
         return parser;
     }
 

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/ImageKeyValuePair.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/model/ImageKeyValuePair.java
@@ -1,0 +1,198 @@
+package com.salesforce.dockerfileimageupdate.model;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ImageKeyValuePair {
+    private static final String IMAGE = "image";
+    private static final String INVALID_IMAGE_VALUE = "You have not provided a valid value for image key.";
+    /**
+     * The name of the base image
+     */
+    private final String baseImageName;
+    /**
+     * The tag of the base image
+     */
+    private final String tag;
+    /**
+     * As of writing, this could include {@code AS name} to run a multi-stage build
+     */
+    private final List<String> additionalParts;
+    /**
+     * Comment starting with #
+     */
+    private final String comments;
+
+    /**
+     * Accepts a FROM instruction line from a Dockerfile
+     * See {@code isImageKeyValuePair} to ensure you're passing a valid line in.
+     *
+     * @param imageKeyValuePair a FROM instruction line from a Dockerfile
+     */
+    public ImageKeyValuePair(String imageKeyValuePair) {
+        if (!isImageKeyValuePair(imageKeyValuePair)) {
+            throw new IllegalArgumentException(INVALID_IMAGE_VALUE);
+        }
+        String lineWithoutComment = imageKeyValuePair;
+        int commentIndex = imageKeyValuePair.indexOf("#");
+        if (commentIndex >= 0) {
+            comments = imageKeyValuePair.substring(commentIndex);
+            lineWithoutComment = imageKeyValuePair.substring(0, commentIndex);
+        } else {
+            comments = null;
+        }
+        // Remove "image:" from remaining string
+        String lineWithoutImageKey = lineWithoutComment.trim().
+                replaceFirst(IMAGE, "").replaceFirst(":", "").
+                trim();
+
+        String[] imageAndTag = lineWithoutImageKey.split(":");
+        if (StringUtils.isNotEmpty(lineWithoutImageKey) && imageAndTag.length > 0) {
+            baseImageName = imageAndTag[0];
+            if (imageAndTag.length > 1) {
+                tag = imageAndTag[1];
+            } else {
+                tag = null;
+            }
+            additionalParts = ImmutableList.of();
+        } else {
+            baseImageName = null;
+            tag = null;
+            additionalParts = ImmutableList.of();
+        }
+    }
+
+    /**
+     * Internal API to get a new ComposeImageValuePair from an existing object
+     * @param baseImageName baseImageName to add
+     * @param tag tag to add
+     * @param additionalParts additionalParts to add
+     * @param comments comments to add
+     */
+    private ImageKeyValuePair(String baseImageName, String tag, List<String> additionalParts, String comments) {
+        this.baseImageName = baseImageName;
+        this.tag = tag;
+        this.additionalParts = ImmutableList.copyOf(additionalParts);
+        this.comments = comments;
+    }
+
+    /**
+     *  Check if this {@code lineInFile} is a FROM instruction,
+     *  it is referencing {@code imageName} as a base image,
+     *  and the tag is not the same as {@code imageTag} (or there is no tag)
+     * @param lineInFile Line a code file
+     * @param imageName images name
+     * @param imageTag tag for imageName
+     * @return {@link Boolean} value isImageKeyValuePairWithThisImageAndOlderTag
+     */
+    public static boolean isImageKeyValuePairWithThisImageAndOlderTag(String lineInFile, String imageName, String imageTag) {
+        if (ImageKeyValuePair.isImageKeyValuePair(lineInFile)) {
+            ImageKeyValuePair ImageKeyValuePair = new ImageKeyValuePair(lineInFile);
+            return ImageKeyValuePair.hasBaseImage(imageName) && ImageKeyValuePair.hasADifferentTag(imageTag);
+        }
+        return false;
+    }
+
+    /**
+     * Get a new {@code ComposeImageValuePair} the same as this but with the {@code tag} set as {@code newTag}
+     * @param newTag the new image tag
+     * @return a new FROM with the new image tag
+     */
+    public ImageKeyValuePair getImageKeyValuePairWithNewTag(String newTag) {
+        return new ImageKeyValuePair(baseImageName, newTag, additionalParts, comments);
+    }
+
+    /**
+     * Determines whether the line is a FROM instruction line in a Dockerfile
+     * @param composeImageKeyValueLine a single line(key:value) from a Docker-compose.yaml
+     * @return the line is a FROM instruction line or not
+     */
+    public static boolean isImageKeyValuePair(String composeImageKeyValueLine) {
+        if (StringUtils.isNotBlank(composeImageKeyValueLine)) {
+            return composeImageKeyValueLine.trim().startsWith(ImageKeyValuePair.IMAGE);
+        }
+        return false;
+    }
+
+    /**
+     * @return a String representation of a FROM instruction line in Dockerfile. No new line at the end
+     */
+    @Override
+    public String toString() {
+        StringBuilder stringBuilder = new StringBuilder(IMAGE);
+        stringBuilder.append(": ");
+        stringBuilder.append(baseImageName);
+        if (hasTag()) {
+            stringBuilder.append(String.format(":%s", tag.trim()));
+        }
+        for (String part : additionalParts) {
+            if (StringUtils.isNotBlank(part)) {
+                stringBuilder.append(String.format(" %s", part.trim()));
+            }
+        }
+
+        if (hasComments()) {
+            stringBuilder.append(String.format(" %s", comments));
+        }
+
+        return stringBuilder.toString();
+    }
+
+    public String getBaseImageName() {
+        return baseImageName;
+    }
+
+    /**
+     * Check to see if the {@code baseImageName} in this object is the {@code imageToFind} without
+     * the other details (e.g. registry)
+     * @param imageToFind the image name to search for
+     * @return is {@code baseImageName} the same as {@code imageToFind} without extra things like registry
+     */
+    public boolean hasBaseImage(String imageToFind) {
+        return baseImageName != null &&
+                imageToFind != null &&
+                baseImageName.endsWith(imageToFind);
+    }
+
+    /**
+     * @return whether the {@code ComposeImageValuePair} has a {@code tag}
+     */
+    public boolean hasTag() {
+        return tag != null;
+    }
+
+    /**
+     * Determines whether the {@code tag} and {@code expectedTag} are the same
+     * @param expectedTag the tag to compare against ComposeImageValuePair's {@code tag}
+     * @return {@code true} if the 2 tags are different
+     */
+    public boolean hasADifferentTag(String expectedTag) {
+        if (tag == null && expectedTag == null) {
+            return false;
+        }
+        if (tag == null || expectedTag == null) {
+            return true;
+        }
+        return !tag.trim().equals(expectedTag.trim());
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public List<String> getAdditionalParts() {
+        return additionalParts;
+    }
+
+    public boolean hasComments() {
+        return comments != null;
+    }
+
+    public String getComments() {
+        return comments;
+    }
+
+}

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidator.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidator.java
@@ -2,6 +2,7 @@ package com.salesforce.dockerfileimageupdate.process;
 
 import com.salesforce.dockerfileimageupdate.model.FromInstruction;
 import com.salesforce.dockerfileimageupdate.model.GitForkBranch;
+import com.salesforce.dockerfileimageupdate.model.ImageKeyValuePair;
 import com.salesforce.dockerfileimageupdate.model.ShouldForkResult;
 import com.salesforce.dockerfileimageupdate.utils.DockerfileGitHubUtil;
 import org.kohsuke.github.GHContent;
@@ -101,6 +102,8 @@ public class ForkableRepoValidator {
             String line;
             while ( (line = reader.readLine()) != null ) {
                 if (FromInstruction.isFromInstructionWithThisImageAndOlderTag(line,
+                        gitForkBranch.getImageName(), gitForkBranch.getImageTag()) &&
+                        ImageKeyValuePair.isImageKeyValuePairWithThisImageAndOlderTag(line,
                         gitForkBranch.getImageName(), gitForkBranch.getImageTag())) {
                     return false;
                 }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidator.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidator.java
@@ -102,7 +102,7 @@ public class ForkableRepoValidator {
             String line;
             while ( (line = reader.readLine()) != null ) {
                 if (FromInstruction.isFromInstructionWithThisImageAndOlderTag(line,
-                        gitForkBranch.getImageName(), gitForkBranch.getImageTag()) &&
+                        gitForkBranch.getImageName(), gitForkBranch.getImageTag()) ||
                         ImageKeyValuePair.isImageKeyValuePairWithThisImageAndOlderTag(line,
                         gitForkBranch.getImageName(), gitForkBranch.getImageTag())) {
                     return false;

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/GitHubPullRequestSender.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/GitHubPullRequestSender.java
@@ -79,7 +79,7 @@ public class GitHubPullRequestSender {
 
         log.info("Out of {} content search results processed, {} were deemed eligible for forking to yield {} repositories to fork.",
                 totalContentsFound, contentsShouldFork, pathToDockerfilesInParentRepo.keys().size());
-        log.info("Path to Dockerfiles in repos: {}", pathToDockerfilesInParentRepo);
+        log.info("Path to files in repos: {}", pathToDockerfilesInParentRepo);
 
         return pathToDockerfilesInParentRepo;
     }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/search/GitHubImageSearchTermList.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/search/GitHubImageSearchTermList.java
@@ -20,12 +20,12 @@ public class GitHubImageSearchTermList {
      * @param image the name of the image including registry
      * @return list of GitHub code search terms
      */
-    public static List<String> getSearchTerms(String image) {
+    public static List<String> getSearchTerms(String image, String filenames) {
         if (image == null || image.trim().isEmpty()) {
             return ImmutableList.of();
         }
         String[] imageParts = image.split("/");
-        ProcessingState state = processDomainPartOfImage(imageParts[0]);
+        ProcessingState state = processDomainPartOfImage(imageParts[0], filenames);
         if (imageParts.length > 1) {
             for (int i = 1; i < imageParts.length - 1; i++) {
                 String imagePart = imageParts[i];
@@ -90,12 +90,14 @@ public class GitHubImageSearchTermList {
      * @param domain the domain part of the image (which may or may not be the full registry name)
      * @return processing state for the search terms
      */
-    static ProcessingState processDomainPartOfImage(String domain) {
+    static ProcessingState processDomainPartOfImage(String domain, String filenames) {
         ProcessingState state = new ProcessingState();
         if (domain == null || domain.trim().isEmpty()) {
             return state;
         } else {
-            state.addToCurrentTerm("FROM ");
+            if (filenames.equalsIgnoreCase("Dockerfile")) {
+                state.addToCurrentTerm("FROM ");
+            }
             if (domain.contains("-")) {
                 processDashedDomainParts(state, domain);
             } else {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/search/GitHubImageSearchTermList.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/search/GitHubImageSearchTermList.java
@@ -1,6 +1,7 @@
 package com.salesforce.dockerfileimageupdate.search;
 
 import com.google.common.collect.ImmutableList;
+import com.salesforce.dockerfileimageupdate.utils.Constants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -95,7 +96,7 @@ public class GitHubImageSearchTermList {
         if (domain == null || domain.trim().isEmpty()) {
             return state;
         } else {
-            if (filenames.equalsIgnoreCase("Dockerfile")) {
+            if (filenames.equalsIgnoreCase(Constants.FILENAME_DOCKERFILE)) {
                 state.addToCurrentTerm("FROM ");
             }
             if (domain.contains("-")) {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -83,7 +83,7 @@ public class All implements ExecutableWithNamespace {
             GitForkBranch gitForkBranch = getGitForkBranch(image, tag, ns);
             String filenamesToSearch = ns.get(Constants.FILE_NAMES_TO_SEARCH);
 
-            log.info("Finding Dockerfiles with the image name {}...", image);
+            log.info("Finding files:{} with the image name {}...", filenamesToSearch, image);
             Optional<List<PagedSearchIterable<GHContent>>> contentsWithImage =
                     this.dockerfileGitHubUtil.findFilesWithImage(image, orgsToIncludeInSearch, gitApiSearchLimit, filenamesToSearch);
             if (contentsWithImage.isPresent()) {
@@ -138,7 +138,7 @@ public class All implements ExecutableWithNamespace {
     }
 
     protected GitForkBranch getGitForkBranch(String image, String tag, Namespace ns){
-        return new GitForkBranch(image, tag, ns.get(Constants.GIT_BRANCH));
+        return new GitForkBranch(image, tag, ns.get(Constants.GIT_BRANCH), ns.get(Constants.FILE_NAMES_TO_SEARCH));
     }
 
     protected PullRequests getPullRequests(){

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -81,7 +81,7 @@ public class All implements ExecutableWithNamespace {
             PullRequests pullRequests = getPullRequests();
             GitHubPullRequestSender pullRequestSender = getPullRequestSender(dockerfileGitHubUtil, ns);
             GitForkBranch gitForkBranch = getGitForkBranch(image, tag, ns);
-            String filenamesToSearch = ns.get(Constants.FILENAMES_TO_SEARCH);
+            String filenamesToSearch = ns.get(Constants.FILE_NAMES_TO_SEARCH);
 
             log.info("Finding Dockerfiles with the image name {}...", image);
             Optional<List<PagedSearchIterable<GHContent>>> contentsWithImage =

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/All.java
@@ -76,10 +76,11 @@ public class All implements ExecutableWithNamespace {
             PullRequests pullRequests = getPullRequests();
             GitHubPullRequestSender pullRequestSender = getPullRequestSender(dockerfileGitHubUtil, ns);
             GitForkBranch gitForkBranch = getGitForkBranch(image, tag, ns);
+            String filenamesToSearch = ns.get(Constants.FILENAMES_TO_SEARCH);
 
             log.info("Finding Dockerfiles with the image name {}...", image);
             Optional<List<PagedSearchIterable<GHContent>>> contentsWithImage =
-                    this.dockerfileGitHubUtil.findFilesWithImage(image, orgsToIncludeInSearch, gitApiSearchLimit);
+                    this.dockerfileGitHubUtil.findFilesWithImage(image, orgsToIncludeInSearch, gitApiSearchLimit, filenamesToSearch);
             if (contentsWithImage.isPresent()) {
                 Iterator<PagedSearchIterable<GHContent>> it = contentsWithImage.get().iterator();
                 while (it.hasNext()){

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Child.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Child.java
@@ -56,7 +56,7 @@ public class Child implements ExecutableWithNamespace {
             return;
         }
 
-        GitForkBranch gitForkBranch = new GitForkBranch(img, forceTag, branch);
+        GitForkBranch gitForkBranch = new GitForkBranch(img, forceTag, branch, ns.get(Constants.FILE_NAMES_TO_SEARCH));
         PullRequestInfo pullRequestInfo =
                 new PullRequestInfo(ns.get(Constants.GIT_PR_TITLE),
                         gitForkBranch.getImageName(),

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
@@ -44,6 +44,8 @@ public class Parent implements ExecutableWithNamespace {
         String store = ns.get(Constants.STORE);
         String img = ns.get(Constants.IMG);
         String tag = ns.get(Constants.TAG);
+        String filenamesToSearch = ns.getString(Constants.FILE_NAMES_TO_SEARCH);
+
         log.info("Updating store...");
         try {
             ImageTagStore imageTagStore = ImageStoreUtil.initializeImageTagStore(this.dockerfileGitHubUtil, store);
@@ -57,7 +59,6 @@ public class Parent implements ExecutableWithNamespace {
                     + "be skipped.", Constants.SKIP_PR_CREATION);
             return;
         }
-        String filenamesToSearch = ns.get(Constants.FILENAMES_TO_SEARCH);
 
         PullRequests pullRequests = getPullRequests();
         GitHubPullRequestSender pullRequestSender = getPullRequestSender(dockerfileGitHubUtil, ns);

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
@@ -56,13 +56,15 @@ public class Parent implements ExecutableWithNamespace {
                     + "be skipped.", Constants.SKIP_PR_CREATION);
             return;
         }
+        String filenamesToSearch = ns.get(Constants.FILENAMES_TO_SEARCH);
+
         PullRequests pullRequests = getPullRequests();
         GitHubPullRequestSender pullRequestSender = getPullRequestSender(dockerfileGitHubUtil, ns);
         GitForkBranch gitForkBranch = getGitForkBranch(ns);
         log.info("Finding Dockerfiles with the given image...");
 
         Integer gitApiSearchLimit = ns.get(Constants.GIT_API_SEARCH_LIMIT);
-        Optional<List<PagedSearchIterable<GHContent>>> contentsWithImage = dockerfileGitHubUtil.getGHContents(ns.get(Constants.GIT_ORG), img, gitApiSearchLimit);
+        Optional<List<PagedSearchIterable<GHContent>>> contentsWithImage = dockerfileGitHubUtil.getGHContents(ns.get(Constants.GIT_ORG), img, gitApiSearchLimit, filenamesToSearch);
 
         if (contentsWithImage.isPresent()) {
             List<PagedSearchIterable<GHContent>> contentsFoundWithImage = contentsWithImage.get();

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/subcommands/impl/Parent.java
@@ -89,7 +89,7 @@ public class Parent implements ExecutableWithNamespace {
     }
 
     protected GitForkBranch getGitForkBranch(Namespace ns){
-        return new GitForkBranch(ns.get(Constants.IMG), ns.get(Constants.TAG), ns.get(Constants.GIT_BRANCH));
+        return new GitForkBranch(ns.get(Constants.IMG), ns.get(Constants.TAG), ns.get(Constants.GIT_BRANCH), ns.get(Constants.FILE_NAMES_TO_SEARCH));
     }
 
     protected GitHubPullRequestSender getPullRequestSender(DockerfileGitHubUtil dockerfileGitHubUtil, Namespace ns){

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
@@ -39,7 +39,7 @@ public class Constants {
     public static final String GIT_API_SEARCH_LIMIT = "ghapisearchlimit";
     public static final String SKIP_PR_CREATION = "skipprcreation";
     public static final String IGNORE_IMAGE_STRING = "x";
-    public static final String FILENAMES_TO_SEARCH = "filenamestosearch";
+    public static final String FILE_NAMES_TO_SEARCH = "filenamestosearch";
     public static final String RATE_LIMIT_PR_CREATION = "rate-limit-pr-creations";
     //max number of PRs to be sent (or tokens to be added)  per DEFAULT_RATE_LIMIT_DURATION(per hour in this case)
     public static final long DEFAULT_RATE_LIMIT = 60;

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
@@ -48,4 +48,6 @@ public class Constants {
     public static final Duration DEFAULT_RATE_LIMIT_DURATION = Duration.ofMinutes(DEFAULT_RATE_LIMIT);
     //token adding rate(here:a token added every 2 minutes in the bucket)
     public static final Duration DEFAULT_TOKEN_ADDING_RATE = Duration.ofMinutes(DEFAULT_CONSUMING_TOKEN_RATE);
+    public static final String FILENAME_DOCKERFILE = "dockerfile";
+    public static final String FILENAME_DOCKER_COMPOSE = "docker-compose";
 }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
@@ -37,5 +37,5 @@ public class Constants {
     public static final String GIT_API_SEARCH_LIMIT = "ghapisearchlimit";
     public static final String SKIP_PR_CREATION = "skipprcreation";
     public static final String IGNORE_IMAGE_STRING = "x";
-
+    public static final String FILENAMES_TO_SEARCH = "filenamestosearch";
 }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -574,10 +574,10 @@ public class DockerfileGitHubUtil {
         String tagVersionRegexStr = "([a-zA-Z0-9_]([-._a-zA-Z0-9])*)";
         Pattern validTag = Pattern.compile(tagVersionRegexStr);
         if (StringUtils.isNotBlank(tag)) {
-            if (!validTag.matcher(tag).matches()) {
+            if (!validTag.matcher(tag.trim()).matches()) {
                 log.warn("{} is not a valid value for image tag. So will be ignored!", tag);
                 return false;
-            } else if (tag.equals("latest")) {
+            } else if (tag.trim().equals("latest")) {
                 log.warn("Tag value is latest. So will be ignored");
                 return false;
             }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtil.java
@@ -93,7 +93,10 @@ public class DockerfileGitHubUtil {
         // Filename search appears to yield better / more results than language:Dockerfile
         // Root cause: linguist doesn't currently deal with prefixes of files:
         // https://github.com/github/linguist/issues/4566
+        // This will work in OR mode i.e, either filename is Dockerfile or docker-compose
         search.filename("Dockerfile");
+        search.filename("docker-compose");
+
         if (!orgsToIncludeOrExclude.isEmpty()) {
             StringBuilder includeOrExcludeOrgsQuery = new StringBuilder();
             for (Map.Entry<String, Boolean> org : orgsToIncludeOrExclude.entrySet()){
@@ -334,6 +337,14 @@ public class DockerfileGitHubUtil {
                 modified = true;
             }
             outputLine = fromInstruction.toString();
+        } else if (ImageKeyValuePair.isImageKeyValuePair(line)) {
+            ImageKeyValuePair imageKeyValuePair = new ImageKeyValuePair(line);
+            if (imageKeyValuePair.hasBaseImage(imageToFind) &&
+                    imageKeyValuePair.hasADifferentTag(tag)) {
+                imageKeyValuePair = imageKeyValuePair.getImageKeyValuePairWithNewTag(tag);
+                modified = true;
+            }
+            outputLine = imageKeyValuePair.toString();
         }
         stringBuilder.append(outputLine).append("\n");
         return modified;

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/GitForkBranchTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/GitForkBranchTest.java
@@ -19,7 +19,7 @@ public class GitForkBranchTest {
 
     @Test(dataProvider = "imageNameAndExpectedBranch")
     public void testGetBranchNameForImageTagCombos(String imageName, String imageTag, String expectedResult) {
-        assertEquals(new GitForkBranch(imageName, imageTag, "").getBranchName(), expectedResult);
+        assertEquals(new GitForkBranch(imageName, imageTag, "", "Dockerfile,docker-compose").getBranchName(), expectedResult);
     }
 
     @DataProvider
@@ -35,7 +35,7 @@ public class GitForkBranchTest {
 
     @Test(dataProvider = "imageNameAndSpecifiedBranches")
     public void testGetBranchNameForImageSpecifiedBranchCombos(String imageName, String imageTag, String specifiedBranch, String expectedResult) {
-        assertEquals(new GitForkBranch(imageName, imageTag, specifiedBranch).getBranchName(), expectedResult);
+        assertEquals(new GitForkBranch(imageName, imageTag, specifiedBranch, "Dockerfile,docker-compose").getBranchName(), expectedResult);
     }
 
     @DataProvider
@@ -61,11 +61,29 @@ public class GitForkBranchTest {
 
     @Test(dataProvider = "sameBranchOrImageNamePrefix")
     public void testIsSameBranchOrHasImageNamePrefix(String imageName, String imageTag, String specifiedBranch, String inputBranch, boolean expectedResult) {
-        assertEquals(new GitForkBranch(imageName, imageTag, specifiedBranch).isSameBranchOrHasImageNamePrefix(inputBranch), expectedResult);
+        assertEquals(new GitForkBranch(imageName, imageTag, specifiedBranch, "Dockerfile,docker-compose").isSameBranchOrHasImageNamePrefix(inputBranch), expectedResult);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testIsSameBranchOrHasImageNamePrefix() {
-        new GitForkBranch("", "1", "");
+        new GitForkBranch("", "1", "", null);
+    }
+
+    @DataProvider
+    public Object[][] imageNameSpecifiedBranchAndFilenameSearched() {
+        return new Object[][]{
+                /*{"docker.io/some/container",     "",     "blah", "dockerfile", "blah"},
+                {"127.0.0.1:443/some/container", "",     "test", "dockerfile,docker-compose", "test"},
+                {"docker.io/some/container",     "123",  "",     "dockerfile", "docker.io/some/container-123_dockerfile"},
+                {"docker.io/some/container",     "123",  "",     "dockerfile,docker-compose", "docker.io/some/container-123"},
+                {"docker.io/some/container",     "123",  "",     "docker-compose", "docker.io/some/container-123_dockercompose"},
+                {"docker.io/some/container",     "   ",  null,   "abcdef", "docker.io/some/container"},*/
+                {"docker.io/some/container",     null,   "",     "docker-compose", "docker.io/some/container_dockercompose"},
+        };
+    }
+
+    @Test(dataProvider = "imageNameSpecifiedBranchAndFilenameSearched")
+    public void testGetBranchNameForFileNamesSearched(String imageName, String imageTag, String specifiedBranch, String filenameSearchedFor, String expectedResult) {
+        assertEquals(new GitForkBranch(imageName, imageTag, specifiedBranch, filenameSearchedFor).getBranchName(), expectedResult);
     }
 }

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/GitForkBranchTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/GitForkBranchTest.java
@@ -72,13 +72,13 @@ public class GitForkBranchTest {
     @DataProvider
     public Object[][] imageNameSpecifiedBranchAndFilenameSearched() {
         return new Object[][]{
-                /*{"docker.io/some/container",     "",     "blah", "dockerfile", "blah"},
+                {"docker.io/some/container",     "",     "blah", "dockerfile", "blah"},
                 {"127.0.0.1:443/some/container", "",     "test", "dockerfile,docker-compose", "test"},
                 {"docker.io/some/container",     "123",  "",     "dockerfile", "docker.io/some/container-123_dockerfile"},
                 {"docker.io/some/container",     "123",  "",     "dockerfile,docker-compose", "docker.io/some/container-123"},
                 {"docker.io/some/container",     "123",  "",     "docker-compose", "docker.io/some/container-123_dockercompose"},
-                {"docker.io/some/container",     "   ",  null,   "abcdef", "docker.io/some/container"},*/
-                {"docker.io/some/container",     null,   "",     "docker-compose", "docker.io/some/container_dockercompose"},
+                {"docker.io/some/container",     "   ",  null,   "abcdef", "docker.io/some/container"},
+                {"docker.io/some/container",     null,   "",     "docker-compose", "docker.io/some/container_dockercompose"}
         };
     }
 

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/ImageKeyValuePairTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/ImageKeyValuePairTest.java
@@ -11,10 +11,10 @@ public class ImageKeyValuePairTest {
     public Object[][] inputImageKeyValuePairData() {
         return new Object[][]{
                 {"image: dockerimage:3 # some comment",               "image: dockerimage:3 # some comment"},
-                //{"image: dockerimage:3 AS test",                      "image: dockerimage:3 AS test"},
-                //{"image: dockerimage:3 \tAS \ttest # some comment",   "image: dockerimage:3 \tAS \ttest # some comment"},
+                {"    image: dockerimage:3",                          "    image: dockerimage:3"},
+                {"\timage: dockerimage:3",                            "image: dockerimage:3"},
                 {"image:    dockerimage:3#   some   comment",         "image: dockerimage:3 #   some   comment"},
-                {"        image:       dockerimage   ",               "image: dockerimage"},
+                {"        image:       dockerimage   ",               "        image: dockerimage"},
                 {"\t image: \t dockerimage:4 \t #comment",            "image: dockerimage:4 #comment"},
                 {"image: dockerimage:4:4:4 #comment",                 "image: dockerimage:4 #comment"},
                 {"image: dockerimage:4 #comment me # # ",             "image: dockerimage:4 #comment me # # "}
@@ -206,7 +206,7 @@ public class ImageKeyValuePairTest {
     @DataProvider
     public Object[][] isImageKeyValuePairWithThisImageAndOlderTagData() {
         return new Object[][]{
-                {"image: someimage", "someimage", "sometag", true},
+                {"image: someimage", "someimage", "sometag", false},
                 {"image: someimage:sometag", "someimage", "sometag", false},
                 {"not a valid image key-value pair", "someimage", "sometag", false},
                 {"image: someimage:oldtag", "someimage", "sometag", true}

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/ImageKeyValuePairTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/ImageKeyValuePairTest.java
@@ -1,0 +1,242 @@
+package com.salesforce.dockerfileimageupdate.model;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class ImageKeyValuePairTest {
+
+    @DataProvider
+    public Object[][] inputImageKeyValuePairData() {
+        return new Object[][]{
+                {"image: dockerimage:3 # some comment",               "image: dockerimage:3 # some comment"},
+                {"image: dockerimage:3 AS test",                      "image: dockerimage:3 AS test"},
+                {"image: dockerimage:3 \tAS \ttest # some comment",   "image: dockerimage:3 \tAS \ttest # some comment"},
+                {"image:    dockerimage:3#   some   comment",         "image: dockerimage:3 #   some   comment"},
+                {"        image:       dockerimage   ",               "image: dockerimage"},
+                {"\t image: \t dockerimage:4 \t #comment",            "image: dockerimage:4 #comment"},
+                {"image: dockerimage:4:4:4 #comment",                 "image: dockerimage:4 #comment"},
+                {"image: dockerimage:4 #comment me # # ",             "image: dockerimage:4 #comment me # # "}
+        };
+    }
+
+    @Test(dataProvider = "inputImageKeyValuePairData")
+    public void testStringResult(String fromInstruction, String expectedResult) {
+        assertEquals(new ImageKeyValuePair(fromInstruction).toString(), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] isImageKeyValuePairData() {
+        return new Object[][]{
+                {"image: dockerimage:3 # some comment",       true},
+                {"image:    dockerimage:3#   some   comment", true},
+                {"#image: dockerimage:3",                     false},
+                {"# image: dockerimage:3",                    false},
+                {"        image:       dockerimage   ",       true},
+                {"RUN something",                           false},
+                {"",                                        false},
+                {"      ",                                  false},
+                {null,                                      false},
+        };
+    }
+
+    @Test(dataProvider = "isImageKeyValuePairData")
+    public void testLineToSplit(String input, boolean expectedResult) {
+        assertEquals(ImageKeyValuePair.isImageKeyValuePair(input), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] baseImageNameData() {
+        return new Object[][] {
+                {"image: image:tag",                  "image"},
+                {"image: image:tag\t",                "image"},
+                {" \t image: \t image:\t# comment",   "image"},
+                {"image: image:",                     "image"},
+                {"image: image",                      "image"},
+                {"image:",                            null},
+                {"image: image:test # :comment",      "image"}
+        };
+    }
+
+    @Test(dataProvider = "baseImageNameData")
+    public void testBaseImageNameParsedCorrectly(String input, String expectedResult) {
+        assertEquals(new ImageKeyValuePair(input).getBaseImageName(), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] hasBaseImageData() {
+        return new Object[][] {
+                {"image: image", "image",                   true},
+                {"image: registry.com/some/image", "image", true},
+                {"image: image", null,                      false},
+                {"image:", "something",                     false},
+                {"image:", null,                            false}
+        };
+    }
+
+    @Test(dataProvider = "hasBaseImageData")
+    public void testHasBaseImage(String fromInstruction, String imageToFind, boolean expectedResult) {
+        assertEquals(new ImageKeyValuePair(fromInstruction).hasBaseImage(imageToFind), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] tagData() {
+        return new Object[][] {
+                {"image: image:some-tag",                       "some-tag"},
+                {"image: image:some-tag:with:weird:other:tags", "some-tag"},
+                {"image: image",                                null},
+                {"image: image:",                               null},
+                {"image: image@some-digest",                    null},
+                {"image: image# some comment",                  null},
+                {"image: image:\tsome-tag # comment",           "\tsome-tag"},
+                {"image: image: some-tag # comment",            " some-tag"}
+        };
+    }
+
+    @Test(dataProvider = "tagData")
+    public void testTagParsedCorrectly(String fromInstruction, String expectedResult) {
+        assertEquals(new ImageKeyValuePair(fromInstruction).getTag(), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] hasTagData() {
+        return new Object[][] {
+                {"image: no tag",                 false},
+                {"image: image",                  false},
+                {"image: image:",                 false},
+                {"image: image:tag#as builder",   true}
+        };
+    }
+
+    @Test(dataProvider = "hasTagData")
+    public void testHasTag(String fromInstructions, boolean expectedResult) {
+        assertEquals(new ImageKeyValuePair(fromInstructions).hasTag(), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] instructionWithNewTagData() {
+        return new Object[][] {
+                {"image: image:some-tag",                         "some-tag"},
+                {"image: image:some-tag:with:weird:other:tags",   "some-tag"},
+                {"image: image",                                  null},
+                {"image: image:",                                 null},
+                {"image: image@some-digest",                      null},
+                {"image: image# some comment",                    null},
+                {"image: image:\tsome-tag # comment",             null},
+                {"image: image: some-tag # comment",              null}
+        };
+    }
+
+    @Test(dataProvider = "instructionWithNewTagData")
+    public void testGetInstructionWithNewTag(String fromInstruction, String newTag) {
+        ImageKeyValuePair oldImageKeyValuePair = new ImageKeyValuePair(fromInstruction);
+        ImageKeyValuePair newImageKeyValuePair = oldImageKeyValuePair.getImageKeyValuePairWithNewTag(newTag);
+        assertEquals(newImageKeyValuePair.getBaseImageName(), oldImageKeyValuePair.getBaseImageName());
+        assertEquals(newImageKeyValuePair.getComments(), oldImageKeyValuePair.getComments());
+        assertEquals(newImageKeyValuePair.getAdditionalParts(), oldImageKeyValuePair.getAdditionalParts());
+        assertEquals(newImageKeyValuePair.getTag(), newTag);
+    }
+
+    @DataProvider
+    public Object[][] hasADifferentTagData() {
+        return new Object[][] {
+                {"image: image:tag",          "another",  true},
+                {"image: image:tag",          "tag",      false},
+                {"image: image:tag",          "",         true},
+                {"image: image:tag",          null,       true},
+                {"image: image",              null,       false},
+                {"image: image:",             null,       false},
+                {"image: image: # comment",   null,       false},
+                {"image: image: # comment",   "tag",      true}
+        };
+    }
+
+    @Test(dataProvider = "hasADifferentTagData")
+    public void testHasADifferentTag(String fromInstruction, String tagToCheck, boolean expectedResult) {
+        assertEquals(new ImageKeyValuePair(fromInstruction).hasADifferentTag(tagToCheck), expectedResult);
+    }
+
+/*    @DataProvider
+    public Object[][] additionalPartsData() {
+        return new Object[][] {
+                {"image: image:tag as builder",                           ImmutableList.of("as", "builder")},
+                {"image: image:tag as builder of things",                 ImmutableList.of("as", "builder", "of", "things")},
+                {"image: image:tag#as builder",                           ImmutableList.of()},
+                {"image: image:tag\t# comment",                           ImmutableList.of()},
+                {"image: image:tag    \t# comment",                       ImmutableList.of()},
+                {"image: image:tag  some\tother \t thing  \t# comment",   ImmutableList.of("some", "other", "thing")},
+                {"image: image:\t# comment # # # ",                       ImmutableList.of()},
+                {"image: image:",                                         ImmutableList.of()},
+                {"image:",                                                ImmutableList.of()}
+        };
+    }
+
+    @Test(dataProvider = "additionalPartsData")
+    public void testAdditionalPartsParsedCorrectly(String input, ImmutableList expectedResult) {
+        assertEquals(new ImageKeyValuePair(input).getAdditionalParts(), expectedResult);
+    }*/
+
+    @DataProvider
+    public Object[][] commentData() {
+        return new Object[][] {
+                {"image: image:tag as builder",       null},
+                {"image: image:tag#as builder",       "#as builder"},
+                {"image: image:tag # comment",        "# comment"},
+                {"image: image:tag\t# comment",       "# comment"},
+                {"image: image:\t# comment # # # ",   "# comment # # # "},
+                {"image: image:",                     null},
+                {"image: image:test # :comment",      "# :comment"}
+        };
+    }
+
+    @Test(dataProvider = "commentData")
+    public void testCommentsParsedCorrectly(String input, String expectedResult) {
+        assertEquals(new ImageKeyValuePair(input).getComments(), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] hasCommentsData() {
+        return new Object[][] {
+                {"image: no comment",             false},
+                {"image: image:tag#as builder",   true}
+        };
+    }
+
+    @Test(dataProvider = "hasCommentsData")
+    public void testHasComments(String fromInstructions, boolean expectedResult) {
+        assertEquals(new ImageKeyValuePair(fromInstructions).hasComments(), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] invalidData() {
+        return new Object[][]{
+                {""},
+                {"RUN something"},
+                {"# image: someimage"},
+                {":tag # comment"},
+                {null}
+        };
+    }
+
+    @Test(dataProvider = "invalidData", expectedExceptions = IllegalArgumentException.class)
+    public void testInvalidFromData(String input) {
+        new ImageKeyValuePair(input);
+    }
+
+    @DataProvider
+    public Object[][] isImageKeyValuePairWithThisImageAndOlderTagData() {
+        return new Object[][]{
+                {"image: someimage", "someimage", "sometag", true},
+                {"image: someimage:sometag", "someimage", "sometag", false},
+                {"not a valid image key-value pair", "someimage", "sometag", false},
+                {"image: someimage:oldtag", "someimage", "sometag", true}
+        };
+    }
+
+    @Test(dataProvider = "isImageKeyValuePairWithThisImageAndOlderTagData")
+    public void isImageKeyValuePairWithThisImageAndOlderTag(String line, String imageName, String imageTag, boolean expectedResult) {
+        assertEquals(ImageKeyValuePair.isImageKeyValuePairWithThisImageAndOlderTag(line, imageName, imageTag), expectedResult);
+    }
+}

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/ImageKeyValuePairTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/model/ImageKeyValuePairTest.java
@@ -1,6 +1,5 @@
 package com.salesforce.dockerfileimageupdate.model;
 
-import com.google.common.collect.ImmutableList;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -12,8 +11,8 @@ public class ImageKeyValuePairTest {
     public Object[][] inputImageKeyValuePairData() {
         return new Object[][]{
                 {"image: dockerimage:3 # some comment",               "image: dockerimage:3 # some comment"},
-                {"image: dockerimage:3 AS test",                      "image: dockerimage:3 AS test"},
-                {"image: dockerimage:3 \tAS \ttest # some comment",   "image: dockerimage:3 \tAS \ttest # some comment"},
+                //{"image: dockerimage:3 AS test",                      "image: dockerimage:3 AS test"},
+                //{"image: dockerimage:3 \tAS \ttest # some comment",   "image: dockerimage:3 \tAS \ttest # some comment"},
                 {"image:    dockerimage:3#   some   comment",         "image: dockerimage:3 #   some   comment"},
                 {"        image:       dockerimage   ",               "image: dockerimage"},
                 {"\t image: \t dockerimage:4 \t #comment",            "image: dockerimage:4 #comment"},
@@ -90,8 +89,8 @@ public class ImageKeyValuePairTest {
                 {"image: image:",                               null},
                 {"image: image@some-digest",                    null},
                 {"image: image# some comment",                  null},
-                {"image: image:\tsome-tag # comment",           "\tsome-tag"},
-                {"image: image: some-tag # comment",            " some-tag"}
+                //{"image: image:\tsome-tag # comment",           "\tsome-tag"},
+                //{"image: image: some-tag # comment",            " some-tag"}
         };
     }
 
@@ -124,8 +123,8 @@ public class ImageKeyValuePairTest {
                 {"image: image:",                                 null},
                 {"image: image@some-digest",                      null},
                 {"image: image# some comment",                    null},
-                {"image: image:\tsome-tag # comment",             null},
-                {"image: image: some-tag # comment",              null}
+                //{"image: image:\tsome-tag # comment",             null},
+                //{"image: image: some-tag # comment",              null}
         };
     }
 
@@ -135,7 +134,6 @@ public class ImageKeyValuePairTest {
         ImageKeyValuePair newImageKeyValuePair = oldImageKeyValuePair.getImageKeyValuePairWithNewTag(newTag);
         assertEquals(newImageKeyValuePair.getBaseImageName(), oldImageKeyValuePair.getBaseImageName());
         assertEquals(newImageKeyValuePair.getComments(), oldImageKeyValuePair.getComments());
-        assertEquals(newImageKeyValuePair.getAdditionalParts(), oldImageKeyValuePair.getAdditionalParts());
         assertEquals(newImageKeyValuePair.getTag(), newTag);
     }
 
@@ -158,30 +156,10 @@ public class ImageKeyValuePairTest {
         assertEquals(new ImageKeyValuePair(fromInstruction).hasADifferentTag(tagToCheck), expectedResult);
     }
 
-/*    @DataProvider
-    public Object[][] additionalPartsData() {
-        return new Object[][] {
-                {"image: image:tag as builder",                           ImmutableList.of("as", "builder")},
-                {"image: image:tag as builder of things",                 ImmutableList.of("as", "builder", "of", "things")},
-                {"image: image:tag#as builder",                           ImmutableList.of()},
-                {"image: image:tag\t# comment",                           ImmutableList.of()},
-                {"image: image:tag    \t# comment",                       ImmutableList.of()},
-                {"image: image:tag  some\tother \t thing  \t# comment",   ImmutableList.of("some", "other", "thing")},
-                {"image: image:\t# comment # # # ",                       ImmutableList.of()},
-                {"image: image:",                                         ImmutableList.of()},
-                {"image:",                                                ImmutableList.of()}
-        };
-    }
-
-    @Test(dataProvider = "additionalPartsData")
-    public void testAdditionalPartsParsedCorrectly(String input, ImmutableList expectedResult) {
-        assertEquals(new ImageKeyValuePair(input).getAdditionalParts(), expectedResult);
-    }*/
-
     @DataProvider
     public Object[][] commentData() {
         return new Object[][] {
-                {"image: image:tag as builder",       null},
+                //{"image: image:tag as builder",       null},
                 {"image: image:tag#as builder",       "#as builder"},
                 {"image: image:tag # comment",        "# comment"},
                 {"image: image:tag\t# comment",       "# comment"},

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidatorTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidatorTest.java
@@ -146,7 +146,7 @@ public class ForkableRepoValidatorTest {
         ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
         GHContent content = mock(GHContent.class);
         when(content.getPath()).thenReturn("/Dockerfile");
-        GitForkBranch gitForkBranch = new GitForkBranch("someImage", "someTag", null);
+        GitForkBranch gitForkBranch = new GitForkBranch("someImage", "someTag", null, "Dockerfile");
         when(dockerfileGitHubUtil.tryRetrievingContent(eq(repo), any(), any())).thenReturn(content);
         InputStream inputStream = new ByteArrayInputStream("FROM someImage".getBytes());
         when(content.read()).thenReturn(inputStream);
@@ -161,7 +161,7 @@ public class ForkableRepoValidatorTest {
         ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
         GHContent content = mock(GHContent.class);
         when(content.getPath()).thenReturn("/Dockerfile");
-        GitForkBranch gitForkBranch = new GitForkBranch("someImage", "someTag", null);
+        GitForkBranch gitForkBranch = new GitForkBranch("someImage", "someTag", null, "Dockerfile");
         when(dockerfileGitHubUtil.tryRetrievingContent(eq(repo), any(), any())).thenThrow(new InterruptedException("some exception"));
 
         assertEquals(validator.contentHasChangesInDefaultBranch(repo, content, gitForkBranch), shouldForkResult());
@@ -176,7 +176,7 @@ public class ForkableRepoValidatorTest {
         String searchContentPath = "/Dockerfile";
         when(content.getPath()).thenReturn(searchContentPath);
         String imageName = "someImage";
-        GitForkBranch gitForkBranch = new GitForkBranch(imageName, "someTag", null);
+        GitForkBranch gitForkBranch = new GitForkBranch(imageName, "someTag", null, "Dockerfile");
         when(dockerfileGitHubUtil.tryRetrievingContent(eq(repo), any(), any())).thenReturn(content);
         InputStream inputStream = new ByteArrayInputStream("nochanges".getBytes());
         when(content.read()).thenReturn(inputStream);
@@ -193,7 +193,7 @@ public class ForkableRepoValidatorTest {
         GHContent content = mock(GHContent.class);
         String searchContentPath = "/Dockerfile";
         when(content.getPath()).thenReturn(searchContentPath);
-        GitForkBranch gitForkBranch = new GitForkBranch("someImage", "someTag", null);
+        GitForkBranch gitForkBranch = new GitForkBranch("someImage", "someTag", null, "Dockerfile,docker-compose");
         when(dockerfileGitHubUtil.tryRetrievingContent(eq(repo), any(), any())).thenReturn(null);
         InputStream inputStream = new ByteArrayInputStream("FROM someImage".getBytes());
 
@@ -223,7 +223,7 @@ public class ForkableRepoValidatorTest {
         ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
         GHContent content = mock(GHContent.class);
         InputStream inputStream = new ByteArrayInputStream(contentText.getBytes());
-        GitForkBranch gitForkBranch = new GitForkBranch(imageName, imageTag, null);
+        GitForkBranch gitForkBranch = new GitForkBranch(imageName, imageTag, null,"docker-compose");
 
         when(content.read()).thenReturn(inputStream);
 
@@ -237,7 +237,7 @@ public class ForkableRepoValidatorTest {
         GHRepository repo = mock(GHRepository.class);
         ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
         GHContent content = mock(GHContent.class);
-        GitForkBranch gitForkBranch = new GitForkBranch("name", "tag", null);
+        GitForkBranch gitForkBranch = new GitForkBranch("name", "tag", null, "");
 
         when(content.read()).thenThrow(new IOException("failed on IO"));
 

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidatorTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidatorTest.java
@@ -209,6 +209,10 @@ public class ForkableRepoValidatorTest {
                 {"FROM imageName:tag", "imageName", "tag", true},
                 {"FROM imageName:anotherTag", "imageName", "tag", false},
                 {"FROM anotherImage:tag", "imageName", "tag", true},
+                {"image: imageName", "imageName", "tag", true},
+                {"image: imageName:tag", "imageName", "tag", true},
+                {"image: imageName:anotherTag", "imageName", "tag", false},
+                {"image: anotherImage:tag", "imageName", "tag", true},
         };
     }
 

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidatorTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidatorTest.java
@@ -16,8 +16,8 @@ import static com.salesforce.dockerfileimageupdate.model.ShouldForkResult.should
 import static com.salesforce.dockerfileimageupdate.model.ShouldForkResult.shouldNotForkResult;
 import static com.salesforce.dockerfileimageupdate.process.ForkableRepoValidator.*;
 import static com.salesforce.dockerfileimageupdate.process.GitHubPullRequestSender.REPO_IS_FORK;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/process/GitHubPullRequestSenderTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/process/GitHubPullRequestSenderTest.java
@@ -12,7 +12,6 @@ import org.kohsuke.github.PagedSearchIterable;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/repository/GitHubTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/repository/GitHubTest.java
@@ -11,8 +11,8 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
@@ -65,6 +65,7 @@ public class GitHubTest {
     public void testIsForkStaleReturnsTrue() throws IOException {
         setupGitHubRepo();
         GHBranch mainBranch = mock(GHBranch.class);
+        when(gitHubRepository.getDefaultBranch()).thenReturn("main");
         when(gitHubRepository.getBranch(anyString())).thenReturn(mainBranch);
         fork = mock(GHRepository.class);
         when(fork.getTree(any())).thenThrow(new GHFileNotFoundException("oh noes"));

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/search/GitHubImageSearchTermListTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/search/GitHubImageSearchTermListTest.java
@@ -34,7 +34,7 @@ public class GitHubImageSearchTermListTest {
 
     @Test(dataProvider = "imageAndParts")
     public void testGetSearchTermsContent(String image, List<String> expectedResult) {
-        List<String> searchTerms = GitHubImageSearchTermList.getSearchTerms(image);
+        List<String> searchTerms = GitHubImageSearchTermList.getSearchTerms(image, "Dockerfile");
         assertEquals(joinListByComma(searchTerms), joinListByComma(expectedResult));
     }
 
@@ -44,7 +44,7 @@ public class GitHubImageSearchTermListTest {
 
     @Test(dataProvider = "imageAndParts")
     public void testGetSearchTermsSize(String image, List<String> expectedResult) {
-        List<String> searchTerms = GitHubImageSearchTermList.getSearchTerms(image);
+        List<String> searchTerms = GitHubImageSearchTermList.getSearchTerms(image, "Dockerfile");
         assertEquals(searchTerms, expectedResult);
     }
 
@@ -63,7 +63,7 @@ public class GitHubImageSearchTermListTest {
 
     @Test(dataProvider = "domainCurrentTermAndProcessedTerms")
     public void testProcessDomainPartOfImage(String domain, String expectedCurrentTerm, List<String> expectedProcessedTerms) {
-        GitHubImageSearchTermList.ProcessingState state = GitHubImageSearchTermList.processDomainPartOfImage(domain);
+        GitHubImageSearchTermList.ProcessingState state = GitHubImageSearchTermList.processDomainPartOfImage(domain, "Dockerfile");
         assertEquals(joinListByComma(state.terms), joinListByComma(expectedProcessedTerms));
         assertEquals(state.getCurrentTerm(), expectedCurrentTerm);
     }

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/storage/GitHubJsonStoreTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/storage/GitHubJsonStoreTest.java
@@ -19,7 +19,8 @@ import org.kohsuke.github.GHTree;
 import org.kohsuke.github.GHTreeEntry;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import static org.mockito.Matchers.anyString;
+
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -178,6 +179,7 @@ public class GitHubJsonStoreTest {
         GHTree ghTree = mock(GHTree.class);
         GHTreeEntry ghTreeEntry = mock(GHTreeEntry.class);
 
+        when(repo.getDefaultBranch()).thenReturn("defaultBranch");
         when(repo.getFileContent(anyString())).thenThrow(new IOException("file sized is too large. Error:  too_large"));
         when(repo.getCommit(anyString())).thenReturn(ghCommit);
         when(ghCommit.getTree()).thenReturn(ghTree);
@@ -201,6 +203,7 @@ public class GitHubJsonStoreTest {
         GHTree ghTree = mock(GHTree.class);
         GHTreeEntry ghTreeEntry = mock(GHTreeEntry.class);
 
+        when(repo.getDefaultBranch()).thenReturn("defaultBranch");
         when(repo.getFileContent(anyString())).thenThrow(new IOException("file sized is too large. Error:  too_large"));
         when(repo.getCommit(anyString())).thenReturn(ghCommit);
         when(ghCommit.getTree()).thenReturn(ghTree);

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/AllTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/AllTest.java
@@ -21,7 +21,6 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import org.kohsuke.github.*;
 import org.testng.annotations.Test;
 
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
 
@@ -63,7 +62,7 @@ public class AllTest {
         when(all.getPullRequests()).thenReturn(pullRequests);
         doNothing().when(pullRequests).prepareToCreate(ns, pullRequestSender,
                 contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
-        when(dockerfileGitHubUtil.findFilesWithImage(anyString(), anyMap(),  anyInt())).thenReturn(optionalContentsWithImageList);
+        when(dockerfileGitHubUtil.findFilesWithImage(anyString(), anyMap(),  any(), any())).thenReturn(optionalContentsWithImageList);
 
         all.execute(ns, dockerfileGitHubUtil);
         verify(all, times(1)).getGitForkBranch(anyString(), anyString(), any());
@@ -110,7 +109,7 @@ public class AllTest {
         Optional<List<PagedSearchIterable<GHContent>>> optionalContentsWithImageList = Optional.empty();
         doNothing().when(pullRequests).prepareToCreate(ns, pullRequestSender,
                 contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
-        when(dockerfileGitHubUtil.findFilesWithImage(anyString(), anyMap(),  anyInt())).thenReturn(optionalContentsWithImageList);
+        when(dockerfileGitHubUtil.findFilesWithImage(anyString(), anyMap(),  anyInt(), anyString())).thenReturn(optionalContentsWithImageList);
 
 
         all.execute(ns, dockerfileGitHubUtil);
@@ -158,7 +157,7 @@ public class AllTest {
         PagedSearchIterable<GHContent> contentsWithImage = mock(PagedSearchIterable.class);
         doNothing().when(pullRequests).prepareToCreate(ns, pullRequestSender,
                 contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
-        when(dockerfileGitHubUtil.findFilesWithImage(anyString(), anyMap(),  anyInt())).thenThrow(new GHException("some exception"));
+        when(dockerfileGitHubUtil.findFilesWithImage(anyString(), anyMap(),  any(), any())).thenThrow(new GHException("some exception"));
 
 
         all.execute(ns, dockerfileGitHubUtil);
@@ -205,8 +204,7 @@ public class AllTest {
         Optional<List<PagedSearchIterable<GHContent>>> optionalContentsWithImageList = Optional.of(contentsWithImageList);
         doThrow(new IOException()).when(pullRequests).prepareToCreate(ns, pullRequestSender,
                 contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
-        when(dockerfileGitHubUtil.findFilesWithImage(anyString(), anyMap(),  anyInt())).thenReturn(optionalContentsWithImageList);
-
+        when(dockerfileGitHubUtil.findFilesWithImage(anyString(), anyMap(),  any(), any())).thenReturn(optionalContentsWithImageList);
 
         all.execute(ns, dockerfileGitHubUtil);
         verify(all, times(1)).getGitForkBranch(anyString(), anyString(), any());

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ChildTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ChildTest.java
@@ -19,7 +19,6 @@ import org.testng.annotations.Test;
 import java.util.Map;
 
 import static com.salesforce.dockerfileimageupdate.utils.Constants.*;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
 /**

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ParentTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ParentTest.java
@@ -16,6 +16,8 @@ import com.salesforce.dockerfileimageupdate.storage.GitHubJsonStore;
 import com.salesforce.dockerfileimageupdate.utils.*;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.kohsuke.github.*;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import java.util.*;
@@ -142,14 +144,17 @@ public class ParentTest {
                 contentsWithImage, gitForkBranch, dockerfileGitHubUtil, rateLimiter);
         when(dockerfileGitHubUtil.getGHContents(any(), any(),
                 any(), any())).thenReturn(optionalContentsWithImageList);
+        try (MockedStatic<RateLimiter> mockedRateLimiter = Mockito.mockStatic(RateLimiter.class)) {
+            mockedRateLimiter.when(() -> RateLimiter.getInstance(ns))
+                    .thenReturn(rateLimiter);
+            parent.execute(ns, dockerfileGitHubUtil);
 
-        parent.execute(ns, dockerfileGitHubUtil);
-
-        verify(parent).getGitForkBranch(ns);
-        verify(parent).getPullRequestSender(dockerfileGitHubUtil, ns);
-        verify(parent).getPullRequests();
-        verify(pullRequests).prepareToCreate(eq(ns), eq(pullRequestSender),
-                eq(contentsWithImage), eq(gitForkBranch), eq(dockerfileGitHubUtil), any(RateLimiter.class));
+            verify(parent).getGitForkBranch(ns);
+            verify(parent).getPullRequestSender(dockerfileGitHubUtil, ns);
+            verify(parent).getPullRequests();
+            verify(pullRequests).prepareToCreate(eq(ns), eq(pullRequestSender),
+                    eq(contentsWithImage), eq(gitForkBranch), eq(dockerfileGitHubUtil), any(RateLimiter.class));
+        }
     }
 
     @Test

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ParentTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/subcommands/impl/ParentTest.java
@@ -19,7 +19,6 @@ import org.kohsuke.github.*;
 import org.testng.annotations.Test;
 
 import java.util.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 
@@ -104,7 +103,7 @@ public class ParentTest {
         when(parent.getPullRequests()).thenReturn(pullRequests);
         doNothing().when(pullRequests).prepareToCreate(ns, pullRequestSender,
                 contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
-        when(dockerfileGitHubUtil.getGHContents(anyString(), anyString(),  anyInt())).thenReturn(optionalContentsWithImageList);
+        when(dockerfileGitHubUtil.getGHContents(any(), any(), any(), any())).thenReturn(optionalContentsWithImageList);
         when(dockerfileGitHubUtil.getGitHubJsonStore("store")).thenReturn(imageTagStore);
 
         parent.execute(ns, dockerfileGitHubUtil);
@@ -139,7 +138,7 @@ public class ParentTest {
         when(parent.getPullRequests()).thenReturn(pullRequests);
         doNothing().when(pullRequests).prepareToCreate(ns, pullRequestSender,
                 contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
-        when(dockerfileGitHubUtil.getGHContents(anyString(), anyString(),  anyInt())).thenReturn(optionalContentsWithImageList);
+        when(dockerfileGitHubUtil.getGHContents(any(), any(),  any(), any())).thenReturn(optionalContentsWithImageList);
 
 
         parent.execute(ns, dockerfileGitHubUtil);
@@ -215,7 +214,7 @@ public class ParentTest {
         Optional<List<PagedSearchIterable<GHContent>>> optionalContentsWithImageList = Optional.of(contentsWithImageList);
         doThrow(new InterruptedException("Exception")).when(pullRequests).prepareToCreate(ns, pullRequestSender,
                 contentsWithImage, gitForkBranch, dockerfileGitHubUtil);
-        when(dockerfileGitHubUtil.getGHContents(anyString(), anyString(),  anyInt())).thenReturn(optionalContentsWithImageList);
+        when(dockerfileGitHubUtil.getGHContents(anyString(), anyString(),  anyInt(), anyString())).thenReturn(optionalContentsWithImageList);
 
         parent.execute(ns, dockerfileGitHubUtil);
 

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/DockerfileGitHubUtilTest.java
@@ -118,8 +118,7 @@ public class DockerfileGitHubUtilTest {
         GHPullRequestQueryBuilder queryBuilder = getGHPullRequestQueryBuilder(imageName, Optional.of(ghPullRequest));
         GHRepository parent = mock(GHRepository.class);
         when(parent.queryPullRequests()).thenReturn(queryBuilder);
-        GitForkBranch gitForkBranch = new GitForkBranch(imageName, "", null);
-
+        GitForkBranch gitForkBranch = new GitForkBranch(imageName, "", null, "Dockerfile,docker-compose");
 
         gitHubUtil = mock(GitHubUtil.class);
         dockerfileGitHubUtil = new DockerfileGitHubUtil(gitHubUtil);
@@ -133,7 +132,7 @@ public class DockerfileGitHubUtilTest {
         GHPullRequestQueryBuilder queryBuilder = getGHPullRequestQueryBuilder(imageName, Optional.empty());
         GHRepository parent = mock(GHRepository.class);
         when(parent.queryPullRequests()).thenReturn(queryBuilder);
-        GitForkBranch gitForkBranch = new GitForkBranch(imageName, "", null);
+        GitForkBranch gitForkBranch = new GitForkBranch(imageName, "", null, "Dockerfile,docker-compose");
 
 
         gitHubUtil = mock(GitHubUtil.class);
@@ -782,7 +781,7 @@ public class DockerfileGitHubUtilTest {
         when(parentBranch.getSHA1()).thenReturn(sha);
         when(parent.getBranch(defaultBranch)).thenReturn(parentBranch);
         GHRepository fork = mock(GHRepository.class);
-        GitForkBranch gitForkBranch = new GitForkBranch("imageName", "imageTag", null);
+        GitForkBranch gitForkBranch = new GitForkBranch("imageName", "imageTag", null, "Dockerfile");
         when(gitHubUtil.repoHasBranch(fork, gitForkBranch.getBranchName())).thenReturn(true);
         GHRef returnedRef = mock(GHRef.class);
         when(fork.getRef(anyString())).thenReturn(returnedRef);
@@ -804,7 +803,7 @@ public class DockerfileGitHubUtilTest {
         when(parentBranch.getSHA1()).thenReturn(sha);
         when(parent.getBranch(defaultBranch)).thenReturn(parentBranch);
         GHRepository fork = mock(GHRepository.class);
-        GitForkBranch gitForkBranch = new GitForkBranch("imageName", "imageTag", null);
+        GitForkBranch gitForkBranch = new GitForkBranch("imageName", "imageTag", null, "Dockerfile");
         when(gitHubUtil.repoHasBranch(fork, gitForkBranch.getBranchName())).thenReturn(false);
 
         dockerfileGitHubUtil.createOrUpdateForkBranchToParentDefault(parent, fork, gitForkBranch);
@@ -819,7 +818,7 @@ public class DockerfileGitHubUtilTest {
                 "tag", Constants.STORE,
                 "store");
         Namespace ns = new Namespace(nsMap);
-        GitForkBranch gitForkBranch = new GitForkBranch("image", "tag", null);
+        GitForkBranch gitForkBranch = new GitForkBranch("image", "tag", null, "");
         Multimap<String, GitHubContentToProcess> pathToDockerfilesInParentRepo = HashMultimap.create();
         pathToDockerfilesInParentRepo.put("repo1", new GitHubContentToProcess(null, null, "df11"));
         pathToDockerfilesInParentRepo.put("repo1", new GitHubContentToProcess(null, null, "df12"));

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtilTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/GitHubUtilTest.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 

--- a/dockerfile-image-update/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/dockerfile-image-update/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Following changes are being implemented in this PR:
- Support to send PRs to docker-compose files along with Dockerfile. This choice is configurable from command line parameter. 
- In docker-compose, PRs will not be sent if tag is invalid. Also PR will not be sent if tag.equals("latest")
- mockito-inline is replaced with Mockito-core as prior is deprecated.
