### PR TITLE
changes in ci, readme and javadoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         id:   version_tag
         run: |
           make get-new-version-from-tag
-          echo "::set-output name=new_version::$(cat new_patch_version.txt)"
+          echo "new_version=$(cat new_patch_version.txt)" >> $GITHUB_OUTPUT
   integration-test:
     runs-on: ubuntu-latest
     needs: [build-test, get-next-version]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         id:   version_tag
         run: |
           make get-new-version-from-tag
-          echo "::set-output name=new_version::$(cat new_patch_version.txt)"
+          echo "new_version=$(cat new_patch_version.txt)" >> $GITHUB_OUTPUT
   integration-test:
     runs-on: ubuntu-latest
     needs: [build-test, get-next-version]

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Before you run the integration tests (locally):
 1. Run integration tests by running
 
    ```
-   make itest-local-changes
+   make integration-test
    ```
 
 ### Release Process

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/RateLimit.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/RateLimit.java
@@ -44,17 +44,17 @@ public class RateLimit {
     }
 
     /**
-     * This method will accept an input string in format <integer>-<ISO-8601_formatted_time> and
+     * This method will accept an input string in format &lt;integer&gt;-&lt;ISO-8601_formatted_time&gt;  and
      * will tokenize it to create a RateLimit object.
      * <pre>
      * Examples of tokenization
-     * input : 500-PT1S -> {rate : 500, duration 1 second (PT1S), token adding rate: every .002 seconds (PT0.002S)}
-     *         60-PT1M -> {rate : 60, duration 1 minute (PT1M), token adding rate: every 1 seconds (PT1S)}
+     * input : 500-PT1S means {rate : 500, duration 1 second (PT1S), token adding rate: every .002 seconds (PT0.002S)}
+     *         60-PT1M means {rate : 60, duration 1 minute (PT1M), token adding rate: every 1 seconds (PT1S)}
      * </pre>
      *
-     * @param input string in format <integer>-<ISO-8601 formatted_time]> example 500-PT1S , 500-PT60S , 500-PT1H
+     * @param input string in format &lt;integer&gt;-&lt;ISO-8601_formatted_time&gt;  example 500-PT1S , 500-PT60S , 500-PT1H
      * @return RateLimit based on the input value
-     * @throws UnknownFormatConversionException if input is not a string with expected format <integer>-<ISO-8601_formatted_time>
+     * @throws UnknownFormatConversionException if input is not a string with expected format &lt;integer&gt;-&lt;ISO-8601_formatted_time&gt;
      */
     public static RateLimit tokenizeAndGetRateLimit(String input) throws UnknownFormatConversionException {
         if (StringUtils.isEmpty(input) || !input.contains("-")) {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/RateLimiter.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/RateLimiter.java
@@ -21,8 +21,7 @@ import org.slf4j.LoggerFactory;
  * time, the number of tokens in the bucket won't exceed the 'rateLimit', limiting the rate at
  * which PRs would be raised. To keep the refill rate uniform, one token will be added to the
  * bucket every 'tokenAddingRate'. If no tokens are left in the bucket, then PR won't be raised
- * and program will halt until next token is available.
- * <pre>
+ * and program will halt until next token is available.</pre>
  */
 public class RateLimiter {
 
@@ -32,11 +31,11 @@ public class RateLimiter {
     /**
      * constructor to initialize RateLimiter with required values.
      * If time meter is not specified, the system default will be chosen.
-     *
-     * @param customTimeMeter Clock to be used for bucketing the tokens.
-     *                        Defaults to TimeMeter.SYSTEM_MILLISECONDS
-     * @param <T>             Implementing class for customTimeMeter must be a class
-     *                        extending TimeMeter
+     * @param rateLimit RateLimit object
+     * @param customTimeMeter custom time metere. should be of type TimeMeter
+     * @param <T> Implementing class for customTimeMeter must be a class
+     *           extending TimeMeter
+     * @see RateLimit
      * @see TimeMeter
      * @see TimeMeter#SYSTEM_MILLISECONDS
      */
@@ -70,7 +69,7 @@ public class RateLimiter {
      * This method will create and return an object of type RateLimiter based on the
      * variable set in the Namespace.
      *
-     * @param ns Namespace {@see net.sourceforge.argparse4j.inf.Namespace}
+     * @param ns Namespace
      * @return RateLimiter object if required variable is set in Namespace
      * null otherwise.
      * @see net.sourceforge.argparse4j.inf.Namespace Namespace


### PR DESCRIPTION
CI : Security Fix https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands. The CI will fail if not fixed by 1st June 2023

Readme: the documented goal doesn't exist in makefile anymore

Javadoc: used the ASCII chars instead of chars