### PR TITLE
Fix uncaught UnsupportedOperationException

### DIFF
--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidator.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidator.java
@@ -108,9 +108,9 @@ public class ForkableRepoValidator {
                     return false;
                 }
             }
-        } catch (IOException exception) {
+        } catch (IOException | UnsupportedOperationException exception) {
             log.warn("Failed while checking if there are changes in {}. Skipping... exception: {}",
-                    content.getPath(), exception.getMessage());
+                    content.getPath(), exception.getMessage(), exception);
         }
         return true;
     }

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidatorTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/process/ForkableRepoValidatorTest.java
@@ -232,7 +232,7 @@ public class ForkableRepoValidatorTest {
     }
 
     @Test
-    public void testHasNoChangesIfExceptionThrownDuringRead() throws IOException {
+    public void testHasNoChangesIfIOExceptionThrownDuringRead() throws IOException {
         DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
         GHRepository repo = mock(GHRepository.class);
         ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
@@ -240,6 +240,19 @@ public class ForkableRepoValidatorTest {
         GitForkBranch gitForkBranch = new GitForkBranch("name", "tag", null, "");
 
         when(content.read()).thenThrow(new IOException("failed on IO"));
+
+        assertTrue(validator.hasNoChanges(content, gitForkBranch));
+    }
+    
+    @Test
+    public void testHasNoChangesIfUnsupportedOperationExceptionThrownDuringRead() throws IOException {
+        DockerfileGitHubUtil dockerfileGitHubUtil = mock(DockerfileGitHubUtil.class);
+        GHRepository repo = mock(GHRepository.class);
+        ForkableRepoValidator validator = new ForkableRepoValidator(dockerfileGitHubUtil);
+        GHContent content = mock(GHContent.class);
+        GitForkBranch gitForkBranch = new GitForkBranch("name", "tag", null, "");
+
+        when(content.read()).thenThrow(new UnsupportedOperationException("Unrecognized encoding: none"));
 
         assertTrue(validator.hasNoChanges(content, gitForkBranch));
     }


### PR DESCRIPTION
Addresses the issue of DFIU aborting if the following exception is throw when reading content from Git.
```
23:11:00  [main] ERROR com.salesforce.dockerfileimageupdate.subcommands.impl.All - Encountered issues while initializing the image tag store or getting its contents. Cannot continue. Exception: 
23:11:00  java.lang.UnsupportedOperationException: Unrecognized encoding: none
23:11:00  	at org.kohsuke.github.GHContent.read(GHContent.java:198)
23:11:00  	at com.salesforce.dockerfileimageupdate.process.ForkableRepoValidator.hasNoChanges(ForkableRepoValidator.java:99)
23:11:00  	at com.salesforce.dockerfileimageupdate.process.ForkableRepoValidator.contentHasChangesInDefaultBranch(ForkableRepoValidator.java:77)
23:11:00  	at com.salesforce.dockerfileimageupdate.process.ForkableRepoValidator.shouldFork(ForkableRepoValidator.java:54)
23:11:00  	at com.salesforce.dockerfileimageupdate.process.GitHubPullRequestSender.forkRepositoriesFoundAndGetPathToDockerfiles(GitHubPullRequestSender.java:67)
23:11:00  	at com.salesforce.dockerfileimageupdate.utils.PullRequests.prepareToCreate(PullRequests.java:22)
23:11:00  	at com.salesforce.dockerfileimageupdate.subcommands.impl.All.processImageWithTag(All.java:93)
23:11:00  	at com.salesforce.dockerfileimageupdate.subcommands.impl.All.processImagesWithTag(All.java:70)
23:11:00  	at com.salesforce.dockerfileimageupdate.subcommands.impl.All.execute(All.java:47)
23:11:00  	at com.salesforce.dockerfileimageupdate.CommandLine.main(CommandLine.java:52)
23:11:00  Unable to run DFIU with the command all
23:11:00  Finished: FAILURE
```