### PR TITLE
Skip DFIU PRs for repos onboarded to Renovate Enterprise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.ipr
 *.iws
 *.iml
+*.DS_Store
 
 # Vim files
 *.swp

--- a/dockerfile-image-update/pom.xml
+++ b/dockerfile-image-update/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20200518</version>
+            <version>20240205</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/dockerfile-image-update/pom.xml
+++ b/dockerfile-image-update/pom.xml
@@ -70,6 +70,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20200518</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
@@ -65,7 +65,7 @@ public class CommandLine {
                 ArgumentParsers.newFor("dockerfile-image-update").addHelp(true).build()
                 .description("Image Updates through Pull Request Automator");
 
-        parser.addArgument("-re", "--" + CHECK_FOR_RENOVATE)
+        parser.addArgument("-R", "--" + CHECK_FOR_RENOVATE)
                 .type(Boolean.class)
                 .setDefault(false) //To prevent null from being returned by the argument
                 .help("Check if Renovate app is being used to receive remediation PRs.");

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/CommandLine.java
@@ -65,6 +65,10 @@ public class CommandLine {
                 ArgumentParsers.newFor("dockerfile-image-update").addHelp(true).build()
                 .description("Image Updates through Pull Request Automator");
 
+        parser.addArgument("-re", "--" + CHECK_FOR_RENOVATE)
+                .type(Boolean.class)
+                .setDefault(false) //To prevent null from being returned by the argument
+                .help("Check if Renovate app is being used to receive remediation PRs.");
         parser.addArgument("-l", "--" + GIT_API_SEARCH_LIMIT)
                 .type(Integer.class)
                 .setDefault(1000)

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
@@ -54,5 +54,5 @@ public class Constants {
 
     public static final String CHECK_FOR_RENOVATE = "checkforrenovate";
 
-    public static final String RENOVATE_CONFIG_FILENAME = "renovate.json";
+    public static final String RENOVATE_CONFIG_FILEPATH = "renovate.json";
 }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
@@ -10,6 +10,7 @@ package com.salesforce.dockerfileimageupdate.utils;
 
 
 import java.time.Duration;
+import java.util.*;
 
 /**
  * @author minho-park
@@ -52,5 +53,6 @@ public class Constants {
     public static final String FILENAME_DOCKERFILE = "dockerfile";
     public static final String FILENAME_DOCKER_COMPOSE = "docker-compose";
     public static final String CHECK_FOR_RENOVATE = "checkforrenovate";
-    public static final String RENOVATE_CONFIG_FILEPATH = "renovate.json";
+    //The Renovate configuration file can be in any one of the following locations. Refer to https://docs.renovatebot.com/configuration-options/
+    public static final List<String> RENOVATE_CONFIG_FILEPATHS = Arrays.asList("renovate.json", "renovate.json5", ".github/renovate.json", ".github/renovate.json5", ".gitlab/renovate.json", ".gitlab/renovate.json5", ".renovaterc", ".renovaterc.json", ".renovaterc.json5");
 }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
@@ -51,4 +51,8 @@ public class Constants {
     public static final Duration DEFAULT_TOKEN_ADDING_RATE = Duration.ofMinutes(DEFAULT_CONSUMING_TOKEN_RATE);
     public static final String FILENAME_DOCKERFILE = "dockerfile";
     public static final String FILENAME_DOCKER_COMPOSE = "docker-compose";
+
+    public static final String CHECK_FOR_RENOVATE = "checkforrenovate";
+
+    public static final String RENOVATE_CONFIG_FILENAME = "renovate.json";
 }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/Constants.java
@@ -51,8 +51,6 @@ public class Constants {
     public static final Duration DEFAULT_TOKEN_ADDING_RATE = Duration.ofMinutes(DEFAULT_CONSUMING_TOKEN_RATE);
     public static final String FILENAME_DOCKERFILE = "dockerfile";
     public static final String FILENAME_DOCKER_COMPOSE = "docker-compose";
-
     public static final String CHECK_FOR_RENOVATE = "checkforrenovate";
-
     public static final String RENOVATE_CONFIG_FILEPATH = "renovate.json";
 }

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/PullRequests.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/PullRequests.java
@@ -4,7 +4,8 @@ import com.google.common.collect.*;
 import com.salesforce.dockerfileimageupdate.model.*;
 import com.salesforce.dockerfileimageupdate.process.*;
 import net.sourceforge.argparse4j.inf.*;
-import org.json.*;
+import org.json.JSONObject;
+import org.json.JSONTokener;
 import org.kohsuke.github.*;
 import org.slf4j.*;
 

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/PullRequests.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/PullRequests.java
@@ -58,7 +58,7 @@ public class PullRequests {
      * @param fork A GitHubContentToProcess object that contains the fork repository that is under process
      * @return true if the file is found in the path specified and is not disabled, false otherwise
      */
-    private boolean isRenovateEnabled(List<String> filePaths, GitHubContentToProcess fork) throws IOException {
+    public boolean isRenovateEnabled(List<String> filePaths, GitHubContentToProcess fork) throws IOException {
         for (String filePath : filePaths) {
             try {
                 GHContent fileContent = fork.getParent().getFileContent(filePath);

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/PullRequests.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/PullRequests.java
@@ -66,7 +66,7 @@ public class PullRequests {
             JSONTokener tokener = new JSONTokener(bufferedReader);
             JSONObject json = new JSONObject(tokener);
             //If the renovate.json file has the key 'enabled' set to false, it indicates that while the repo has been onboarded to renovate, it has been disabled for some reason
-            if (json.has("enabled") && json.get("enabled").toString() == "false") {
+            if (json.has("enabled") && json.getBoolean("enabled") == false) {
                 return false;
             }
         } catch (FileNotFoundException e) {

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/PullRequests.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/PullRequests.java
@@ -61,21 +61,22 @@ public class PullRequests {
     protected boolean isRenovateEnabled(List<String> filePaths, GitHubContentToProcess fork) throws IOException {
         for (String filePath : filePaths) {
             try {
-                GHContent fileContent = fork.getParent().getFileContent(filePath);
-                JSONObject json;
-                try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(fileContent.read()))) {
-                    JSONTokener tokener = new JSONTokener(bufferedReader);
-                    json = new JSONObject(tokener);
-                    //If the file has the key 'enabled' set to false, it indicates that while the repo has been onboarded to renovate, it has been disabled for some reason
-                    return json.optBoolean("enabled", true);
-                } catch (IOException e) {
-                    log.debug("Exception while trying to close a resource. Exception: %s", e.getMessage());
-                }
+                //If the file has the key 'enabled' set to false, it indicates that while the repo has been onboarded to renovate, it has been disabled for some reason
+                return readJsonFromContent(fork.getParent().getFileContent(filePath)).optBoolean("enabled", true);
             } catch (FileNotFoundException e) {
                 log.debug("The file with name %s not found in the repository. Exception: %s", filePath, e.getMessage());
+            } catch (IOException e) {
+                log.debug("Exception while trying to close a resource. Exception: %s", e.getMessage());
             }
         }
         return false;
+    }
+
+    private JSONObject readJsonFromContent(GHContent content) throws IOException {
+        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(content.read()))) {
+            JSONTokener tokener = new JSONTokener(bufferedReader);
+            return new JSONObject(tokener);
+        }
     }
 }
 

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/PullRequests.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/PullRequests.java
@@ -72,6 +72,11 @@ public class PullRequests {
         return false;
     }
 
+    /**
+     * Read the content of a fle from a repository and convert it into a JSON object
+     * @param content The GHContent object for the content in the repository
+     * @return json object for the content read from the repository
+     */
     private JSONObject readJsonFromContent(GHContent content) throws IOException {
         try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(content.read()))) {
             JSONTokener tokener = new JSONTokener(bufferedReader);

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/PullRequests.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/PullRequests.java
@@ -58,13 +58,12 @@ public class PullRequests {
      * @param fork A GitHubContentToProcess object that contains the fork repository that is under process
      * @return true if the file is found in the path specified and is not disabled, false otherwise
      */
-    public boolean isRenovateEnabled(List<String> filePaths, GitHubContentToProcess fork) throws IOException {
+    protected boolean isRenovateEnabled(List<String> filePaths, GitHubContentToProcess fork) throws IOException {
         for (String filePath : filePaths) {
             try {
                 GHContent fileContent = fork.getParent().getFileContent(filePath);
                 JSONObject json;
-                try (InputStream is = fileContent.read();
-                     BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(is))) {
+                try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(fileContent.read()))) {
                     JSONTokener tokener = new JSONTokener(bufferedReader);
                     json = new JSONObject(tokener);
                     //If the file has the key 'enabled' set to false, it indicates that while the repo has been onboarded to renovate, it has been disabled for some reason

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/PullRequests.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/PullRequests.java
@@ -31,8 +31,8 @@ public class PullRequests {
                 try {
                     //If the repository has been onboarded to renovate enterprise, skip sending the DFIU PR
                     if(ns.getBoolean(Constants.CHECK_FOR_RENOVATE)
-                            && (isRenovateEnabled(Constants.RENOVATE_CONFIG_FILEPATH, forkWithContentPaths.get()))) {
-                        log.info("Found file with name %s in the repo %s. Skip sending DFIU PRs to this repository.", Constants.RENOVATE_CONFIG_FILEPATH, forkWithContentPaths.get().getParent().getFullName());
+                            && (isRenovateEnabled(Constants.RENOVATE_CONFIG_FILEPATHS, forkWithContentPaths.get()))) {
+                        log.info("Found a renovate configuration file in the repo %s. Skip sending DFIU PRs to this repository.", forkWithContentPaths.get().getParent().getFullName());
                     } else {
                         dockerfileGitHubUtil.changeDockerfiles(ns,
                                 pathToDockerfilesInParentRepo,
@@ -52,28 +52,29 @@ public class PullRequests {
 
     /**
      * Check if the repository is onboarded to Renovate. The signal we are looking for are
-     * (1) The presence of a file named renovate.json in the root of the repository
+     * (1) The presence of a file where renovate configurations are stored in the repository
      * (2) Ensuring that the file does not have the key "enabled" set to "false"
-     * @param filePath the name of the file that we are searching for in the repo
+     * @param filePaths the list that contains all the names of the files that we are searching for in the repo
      * @param fork A GitHubContentToProcess object that contains the fork repository that is under process
      * @return true if the file is found in the path specified and is not disabled, false otherwise
      */
-    private boolean isRenovateEnabled(String filePath, GitHubContentToProcess fork) throws IOException {
-        try {
-            GHContent fileContent = fork.getParent().getFileContent(filePath);
-            InputStream is = fileContent.read();
-            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(is));
-            JSONTokener tokener = new JSONTokener(bufferedReader);
-            JSONObject json = new JSONObject(tokener);
-            //If the renovate.json file has the key 'enabled' set to false, it indicates that while the repo has been onboarded to renovate, it has been disabled for some reason
-            if (json.has("enabled") && json.getBoolean("enabled") == false) {
-                return false;
+    private boolean isRenovateEnabled(List<String> filePaths, GitHubContentToProcess fork) throws IOException {
+        for (String filePath : filePaths) {
+            try {
+                GHContent fileContent = fork.getParent().getFileContent(filePath);
+                InputStream is = fileContent.read();
+                BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(is));
+                JSONTokener tokener = new JSONTokener(bufferedReader);
+                JSONObject json = new JSONObject(tokener);
+                is.close();
+                bufferedReader.close();
+                //If the file has the key 'enabled' set to false, it indicates that while the repo has been onboarded to renovate, it has been disabled for some reason
+                return json.optBoolean("enabled", true);
+            } catch (FileNotFoundException e) {
+                log.debug("The file with name %s not found in the repository.", filePath);
             }
-        } catch (FileNotFoundException e) {
-            log.debug("The file with name %s not found in the repository.", filePath);
-            return false;
         }
-        return true;
+        return false;
     }
 }
 

--- a/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/PullRequests.java
+++ b/dockerfile-image-update/src/main/java/com/salesforce/dockerfileimageupdate/utils/PullRequests.java
@@ -4,6 +4,7 @@ import com.google.common.collect.*;
 import com.salesforce.dockerfileimageupdate.model.*;
 import com.salesforce.dockerfileimageupdate.process.*;
 import net.sourceforge.argparse4j.inf.*;
+import org.json.*;
 import org.kohsuke.github.*;
 import org.slf4j.*;
 
@@ -27,10 +28,17 @@ public class PullRequests {
                     pathToDockerfilesInParentRepo.get(currUserRepo).stream().findFirst();
             if (forkWithContentPaths.isPresent()) {
                 try {
-                    dockerfileGitHubUtil.changeDockerfiles(ns,
-                            pathToDockerfilesInParentRepo,
-                            forkWithContentPaths.get(), skippedRepos,
-                            gitForkBranch, rateLimiter);
+                    if(ns.getBoolean(Constants.CHECK_FOR_RENOVATE)
+                            && (isRenovateEnabled(Constants.RENOVATE_CONFIG_FILENAME, forkWithContentPaths.get()))) {
+                        log.info("Found file with name %s in the repo %s. Skip sending DFIU PRs.", Constants.RENOVATE_CONFIG_FILENAME, forkWithContentPaths.get().getParent().getFullName());
+                    } else {
+                        dockerfileGitHubUtil.changeDockerfiles(ns,
+                                pathToDockerfilesInParentRepo,
+                                forkWithContentPaths.get(), skippedRepos,
+                                gitForkBranch, rateLimiter);
+                    }
+
+
                 } catch (IOException | InterruptedException e) {
                     log.error(String.format("Error changing Dockerfile for %s", forkWithContentPaths.get().getParent().getFullName()), e);
                     exceptions.add((IOException) e);
@@ -40,6 +48,27 @@ public class PullRequests {
             }
         }
         ResultsProcessor.processResults(skippedRepos, exceptions, log);
+    }
+
+    private boolean isRenovateEnabled(String fileName, GitHubContentToProcess fork) throws IOException {
+        try {
+            GHContent fileContent = fork.getParent().getFileContent(fileName);
+            InputStream is = fileContent.read();
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(is));
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
+                sb.append(line);
+            }
+            JSONObject json = new JSONObject(sb.toString());
+            if (json.has("enabled") && json.get("enabled") == "false") {
+                return false;
+            }
+        } catch (FileNotFoundException e) {
+            log.debug("The file with name %s not found in the repository.");
+            return false;
+        }
+        return true;
     }
 }
 

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/PullRequestsTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/PullRequestsTest.java
@@ -10,7 +10,6 @@ import org.testng.annotations.*;
 
 import java.io.*;
 import java.util.*;
-import java.util.Optional;
 
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertThrows;

--- a/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/PullRequestsTest.java
+++ b/dockerfile-image-update/src/test/java/com/salesforce/dockerfileimageupdate/utils/PullRequestsTest.java
@@ -21,7 +21,7 @@ public class PullRequestsTest {
                 "image", Constants.TAG,
                 "tag", Constants.STORE,
                 "store", Constants.SKIP_PR_CREATION,
-                false);
+                false, Constants.CHECK_FOR_RENOVATE, false);
         Namespace ns = new Namespace(nsMap);
         PullRequests pullRequests = new PullRequests();
         GitHubPullRequestSender pullRequestSender = mock(GitHubPullRequestSender.class);
@@ -51,7 +51,7 @@ public class PullRequestsTest {
                 "image", Constants.TAG,
                 "tag", Constants.STORE,
                 "store", Constants.SKIP_PR_CREATION,
-                false);
+                false, Constants.CHECK_FOR_RENOVATE, false);
         Namespace ns = new Namespace(nsMap);
         PullRequests pullRequests = new PullRequests();
         GitHubPullRequestSender pullRequestSender = mock(GitHubPullRequestSender.class);
@@ -89,7 +89,7 @@ public class PullRequestsTest {
                 "image", Constants.TAG,
                 "tag", Constants.STORE,
                 "store", Constants.SKIP_PR_CREATION,
-                false);
+                false, Constants.CHECK_FOR_RENOVATE, false);
         Namespace ns = new Namespace(nsMap);
         PullRequests pullRequests = new PullRequests();
         GitHubPullRequestSender pullRequestSender = mock(GitHubPullRequestSender.class);


### PR DESCRIPTION
Renovate enterprise is another solution that can be used to receive remediation PRs. This change disables sending DFIU PRs for those repositories that have been onboarded to Renovate Enterprise. 